### PR TITLE
Add CDP shim with HTTP discovery endpoints for Moltbot compatibility

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -20,3 +20,7 @@ CLAWDBOT_GATEWAY_TOKEN=dev-token-change-in-prod
 # Optional chat channels
 # TELEGRAM_BOT_TOKEN=optional
 # DISCORD_BOT_TOKEN=optional
+
+# CDP (Chrome DevTools Protocol) configuration for browser automation
+# CDP_SECRET=shared-secret-for-cdp-auth
+# WORKER_URL=https://your-worker.example.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@cloudflare/puppeteer": "^1.0.5",
         "hono": "^4.11.6",
         "jose": "^6.1.0",
         "react": "^19.0.0",
@@ -363,6 +364,20 @@
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/puppeteer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cloudflare/puppeteer/-/puppeteer-1.0.5.tgz",
+      "integrity": "sha512-sKVtc9eTe+ulDqFGk1AcU1cgw3fuLvT75eqHDApvE1d/ZTesBD/r2Iey6elQ9uq/jBj0SjEOM1GVYi0Rojzeaw==",
+      "dependencies": {
+        "@puppeteer/browsers": "2.2.4",
+        "debug": "^4.3.5",
+        "devtools-protocol": "0.0.1299070",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cloudflare/sandbox": {
@@ -1021,6 +1036,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.4.tgz",
+      "integrity": "sha512-BdG2qiI1dn89OTUUsx2GZSpUzW+DRffR1wlMJyKxVHYrhnKoELSDxDd+2XImUkuWPEKk76H5FcM/gPFrEK1Tfw==",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.4.0",
+        "semver": "^7.6.2",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1401,6 +1437,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1473,7 +1514,7 @@
     },
     "node_modules/@types/node": {
       "version": "22.19.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1497,6 +1538,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1662,6 +1712,36 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1670,6 +1750,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ast-v8-to-istanbul": {
@@ -1702,6 +1793,123 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
+      "integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.18.tgz",
@@ -1710,6 +1918,14 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
+      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/blake3-wasm": {
@@ -1751,6 +1967,37 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001766",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
@@ -1782,6 +2029,35 @@
         "node": ">=18"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1808,11 +2084,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1826,6 +2109,19 @@
         }
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "dev": true,
@@ -1834,12 +2130,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1299070",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1299070.tgz",
+      "integrity": "sha512-+qtL3eX50qsJ7c+qVyagqi7AWMoQCBGNfoyJZMwm/NSXVqLYbuitrWEEIzxfUmTNy7//Xe8yhMmQ+elj3uAqSg=="
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.279",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
       "integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
@@ -2325,10 +2639,49 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estree-walker": {
@@ -2341,6 +2694,22 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2349,6 +2718,38 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -2394,6 +2795,41 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2419,6 +2855,65 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -2594,7 +3089,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2616,6 +3110,14 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -2634,6 +3136,44 @@
       ],
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "dev": true,
@@ -2643,6 +3183,11 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2693,6 +3238,54 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -2720,6 +3313,14 @@
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2777,7 +3378,6 @@
     },
     "node_modules/semver": {
       "version": "7.7.3",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2836,6 +3436,50 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2860,6 +3504,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "dev": true,
@@ -2870,6 +3548,42 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2915,6 +3629,11 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "dev": true,
@@ -2927,6 +3646,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/undici": {
       "version": "7.18.2",
       "dev": true,
@@ -2937,7 +3665,7 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -3260,9 +3988,29 @@
         }
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
     "node_modules/ws": {
       "version": "8.18.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3280,12 +4028,54 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "node_modules/youch": {
       "version": "4.1.0-beta.10",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@cloudflare/puppeteer": "^1.0.5",
     "hono": "^4.11.6",
     "jose": "^6.1.0",
     "react": "^19.0.0",

--- a/src/gateway/env.ts
+++ b/src/gateway/env.ts
@@ -21,6 +21,8 @@ export function buildEnvVars(env: ClawdbotEnv): Record<string, string> {
   if (env.DISCORD_DM_POLICY) envVars.DISCORD_DM_POLICY = env.DISCORD_DM_POLICY;
   if (env.SLACK_BOT_TOKEN) envVars.SLACK_BOT_TOKEN = env.SLACK_BOT_TOKEN;
   if (env.SLACK_APP_TOKEN) envVars.SLACK_APP_TOKEN = env.SLACK_APP_TOKEN;
+  if (env.CDP_SECRET) envVars.CDP_SECRET = env.CDP_SECRET;
+  if (env.WORKER_URL) envVars.WORKER_URL = env.WORKER_URL;
 
   return envVars;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import type { AppEnv, ClawdbotEnv } from './types';
 import { CLAWDBOT_PORT } from './config';
 import { createAccessMiddleware } from './auth';
 import { ensureClawdbotGateway, syncToR2 } from './gateway';
-import { api, admin, debug } from './routes';
+import { api, admin, debug, cdp } from './routes';
 
 export { Sandbox };
 
@@ -99,6 +99,10 @@ app.use('/debug/*', async (c, next) => {
 });
 app.use('/debug/*', createAccessMiddleware({ type: 'json' }));
 app.route('/debug', debug);
+
+// Mount CDP shim routes (authenticated via shared secret, NOT Cloudflare Access)
+// This allows programmatic access from external tools
+app.route('/cdp', cdp);
 
 // All other routes: start clawdbot and proxy
 app.all('*', async (c) => {

--- a/src/routes/cdp.ts
+++ b/src/routes/cdp.ts
@@ -1,0 +1,1858 @@
+import { Hono } from 'hono';
+import type { AppEnv, ClawdbotEnv } from '../types';
+import puppeteer, { type Browser, type Page } from '@cloudflare/puppeteer';
+
+/**
+ * CDP (Chrome DevTools Protocol) WebSocket shim
+ * 
+ * Implements a subset of the CDP protocol over WebSocket, translating commands
+ * to Cloudflare Browser Rendering binding calls (Puppeteer interface).
+ * 
+ * Authentication: Pass secret as query param `?secret=<secret>` on WebSocket connect.
+ * This route is intentionally NOT protected by Cloudflare Access.
+ * 
+ * Supported CDP domains:
+ * - Browser: getVersion, close
+ * - Target: createTarget, closeTarget, getTargets
+ * - Page: navigate, reload, getFrameTree, captureScreenshot, getLayoutMetrics
+ * - Runtime: evaluate
+ * - DOM: getDocument, querySelector, querySelectorAll, getOuterHTML, getAttributes
+ * - Input: dispatchMouseEvent, dispatchKeyEvent, insertText
+ * - Network: enable, disable, setCacheDisabled
+ * - Emulation: setDeviceMetricsOverride, setUserAgentOverride
+ */
+const cdp = new Hono<AppEnv>();
+
+/**
+ * CDP Message types
+ */
+interface CDPRequest {
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface CDPResponse {
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+interface CDPEvent {
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * Session state for a CDP connection
+ */
+interface CDPSession {
+  browser: Browser;
+  pages: Map<string, Page>;  // targetId -> Page
+  defaultTargetId: string;
+  nodeIdCounter: number;
+  nodeMap: Map<number, string>;  // nodeId -> selector path
+  objectIdCounter: number;
+  objectMap: Map<string, unknown>;  // objectId -> value (for Runtime.getProperties)
+  scriptsToEvaluateOnNewDocument: Map<string, string>;  // identifier -> source
+  extraHTTPHeaders: Map<string, string>;  // header name -> value
+  requestInterceptionEnabled: boolean;
+  pendingRequests: Map<string, { request: Request; resolve: (response: Response) => void }>;
+}
+
+/**
+ * GET /cdp - WebSocket upgrade endpoint
+ * 
+ * Connect with: ws://host/cdp?secret=<CDP_SECRET>
+ */
+cdp.get('/', async (c) => {
+  // Check for WebSocket upgrade
+  const upgradeHeader = c.req.header('Upgrade');
+  if (upgradeHeader?.toLowerCase() !== 'websocket') {
+    return c.json({
+      error: 'WebSocket upgrade required',
+      hint: 'Connect via WebSocket: ws://host/cdp?secret=<CDP_SECRET>',
+      supported_methods: [
+        // Browser
+        'Browser.getVersion',
+        'Browser.close',
+        // Target
+        'Target.createTarget',
+        'Target.closeTarget',
+        'Target.getTargets',
+        'Target.attachToTarget',
+        // Page
+        'Page.navigate',
+        'Page.reload',
+        'Page.captureScreenshot',
+        'Page.getFrameTree',
+        'Page.getLayoutMetrics',
+        'Page.bringToFront',
+        'Page.setContent',
+        'Page.printToPDF',
+        'Page.addScriptToEvaluateOnNewDocument',
+        'Page.removeScriptToEvaluateOnNewDocument',
+        'Page.handleJavaScriptDialog',
+        'Page.stopLoading',
+        'Page.getNavigationHistory',
+        'Page.navigateToHistoryEntry',
+        'Page.setBypassCSP',
+        // Runtime
+        'Runtime.evaluate',
+        'Runtime.callFunctionOn',
+        'Runtime.getProperties',
+        'Runtime.releaseObject',
+        'Runtime.releaseObjectGroup',
+        // DOM
+        'DOM.getDocument',
+        'DOM.querySelector',
+        'DOM.querySelectorAll',
+        'DOM.getOuterHTML',
+        'DOM.getAttributes',
+        'DOM.setAttributeValue',
+        'DOM.focus',
+        'DOM.getBoxModel',
+        'DOM.scrollIntoViewIfNeeded',
+        'DOM.removeNode',
+        'DOM.setNodeValue',
+        'DOM.setFileInputFiles',
+        // Input
+        'Input.dispatchMouseEvent',
+        'Input.dispatchKeyEvent',
+        'Input.insertText',
+        // Network
+        'Network.enable',
+        'Network.disable',
+        'Network.setCacheDisabled',
+        'Network.setExtraHTTPHeaders',
+        'Network.setCookie',
+        'Network.setCookies',
+        'Network.getCookies',
+        'Network.deleteCookies',
+        'Network.clearBrowserCookies',
+        'Network.setUserAgentOverride',
+        // Fetch (Request Interception)
+        'Fetch.enable',
+        'Fetch.disable',
+        'Fetch.continueRequest',
+        'Fetch.fulfillRequest',
+        'Fetch.failRequest',
+        'Fetch.getResponseBody',
+        // Emulation
+        'Emulation.setDeviceMetricsOverride',
+        'Emulation.clearDeviceMetricsOverride',
+        'Emulation.setUserAgentOverride',
+        'Emulation.setGeolocationOverride',
+        'Emulation.clearGeolocationOverride',
+        'Emulation.setTimezoneOverride',
+        'Emulation.setTouchEmulationEnabled',
+        'Emulation.setEmulatedMedia',
+        'Emulation.setDefaultBackgroundColorOverride',
+      ],
+    });
+  }
+
+  // Verify secret from query param
+  const url = new URL(c.req.url);
+  const providedSecret = url.searchParams.get('secret');
+  const expectedSecret = c.env.CDP_SECRET;
+
+  if (!expectedSecret) {
+    return c.json({
+      error: 'CDP endpoint not configured',
+      hint: 'Set CDP_SECRET via: wrangler secret put CDP_SECRET',
+    }, 503);
+  }
+
+  if (!providedSecret || !timingSafeEqual(providedSecret, expectedSecret)) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  if (!c.env.BROWSER) {
+    return c.json({
+      error: 'Browser Rendering not configured',
+      hint: 'Add browser binding to wrangler.jsonc',
+    }, 503);
+  }
+
+  // Create WebSocket pair
+  const webSocketPair = new WebSocketPair();
+  const [client, server] = Object.values(webSocketPair);
+
+  // Accept the WebSocket
+  server.accept();
+
+  // Initialize CDP session asynchronously
+  initCDPSession(server, c.env).catch((err) => {
+    console.error('[CDP] Failed to initialize session:', err);
+    server.close(1011, 'Failed to initialize browser session');
+  });
+
+  return new Response(null, {
+    status: 101,
+    webSocket: client,
+  });
+});
+
+/**
+ * GET /json/version - CDP discovery endpoint
+ * 
+ * Returns browser version info and WebSocket URL for Moltbot/Playwright compatibility.
+ * Authentication: Pass secret as query param `?secret=<CDP_SECRET>`
+ */
+cdp.get('/json/version', async (c) => {
+  // Verify secret from query param
+  const url = new URL(c.req.url);
+  const providedSecret = url.searchParams.get('secret');
+  const expectedSecret = c.env.CDP_SECRET;
+
+  if (!expectedSecret) {
+    return c.json({
+      error: 'CDP endpoint not configured',
+      hint: 'Set CDP_SECRET via: wrangler secret put CDP_SECRET',
+    }, 503);
+  }
+
+  if (!providedSecret || !timingSafeEqual(providedSecret, expectedSecret)) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  if (!c.env.BROWSER) {
+    return c.json({
+      error: 'Browser Rendering not configured',
+      hint: 'Add browser binding to wrangler.jsonc',
+    }, 503);
+  }
+
+  // Build the WebSocket URL - preserve the secret in the WS URL
+  const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = `${wsProtocol}//${url.host}/cdp?secret=${encodeURIComponent(providedSecret)}`;
+
+  return c.json({
+    'Browser': 'Cloudflare-Browser-Rendering/1.0',
+    'Protocol-Version': '1.3',
+    'User-Agent': 'Mozilla/5.0 Cloudflare Browser Rendering',
+    'V8-Version': 'cloudflare',
+    'WebKit-Version': 'cloudflare',
+    'webSocketDebuggerUrl': wsUrl,
+  });
+});
+
+/**
+ * GET /json/list - List available targets (tabs)
+ * 
+ * Returns a list of available browser targets for Moltbot/Playwright compatibility.
+ * Note: Since we create targets on-demand per WebSocket connection, this returns
+ * a placeholder target that will be created when connecting.
+ * Authentication: Pass secret as query param `?secret=<CDP_SECRET>`
+ */
+cdp.get('/json/list', async (c) => {
+  // Verify secret from query param
+  const url = new URL(c.req.url);
+  const providedSecret = url.searchParams.get('secret');
+  const expectedSecret = c.env.CDP_SECRET;
+
+  if (!expectedSecret) {
+    return c.json({
+      error: 'CDP endpoint not configured',
+      hint: 'Set CDP_SECRET via: wrangler secret put CDP_SECRET',
+    }, 503);
+  }
+
+  if (!providedSecret || !timingSafeEqual(providedSecret, expectedSecret)) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  if (!c.env.BROWSER) {
+    return c.json({
+      error: 'Browser Rendering not configured',
+      hint: 'Add browser binding to wrangler.jsonc',
+    }, 503);
+  }
+
+  // Build the WebSocket URL
+  const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = `${wsProtocol}//${url.host}/cdp?secret=${encodeURIComponent(providedSecret)}`;
+
+  // Return a placeholder target - actual target is created on WS connect
+  return c.json([
+    {
+      'description': '',
+      'devtoolsFrontendUrl': '',
+      'id': 'cloudflare-browser',
+      'title': 'Cloudflare Browser Rendering',
+      'type': 'page',
+      'url': 'about:blank',
+      'webSocketDebuggerUrl': wsUrl,
+    },
+  ]);
+});
+
+/**
+ * GET /json - Alias for /json/list (some clients use this)
+ */
+cdp.get('/json', async (c) => {
+  // Redirect internally to /json/list handler
+  const url = new URL(c.req.url);
+  url.pathname = url.pathname.replace(/\/json\/?$/, '/json/list');
+  
+  // Verify secret from query param
+  const providedSecret = url.searchParams.get('secret');
+  const expectedSecret = c.env.CDP_SECRET;
+
+  if (!expectedSecret) {
+    return c.json({
+      error: 'CDP endpoint not configured',
+      hint: 'Set CDP_SECRET via: wrangler secret put CDP_SECRET',
+    }, 503);
+  }
+
+  if (!providedSecret || !timingSafeEqual(providedSecret, expectedSecret)) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  if (!c.env.BROWSER) {
+    return c.json({
+      error: 'Browser Rendering not configured',
+      hint: 'Add browser binding to wrangler.jsonc',
+    }, 503);
+  }
+
+  // Build the WebSocket URL
+  const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = `${wsProtocol}//${url.host}/cdp?secret=${encodeURIComponent(providedSecret)}`;
+
+  return c.json([
+    {
+      'description': '',
+      'devtoolsFrontendUrl': '',
+      'id': 'cloudflare-browser',
+      'title': 'Cloudflare Browser Rendering',
+      'type': 'page',
+      'url': 'about:blank',
+      'webSocketDebuggerUrl': wsUrl,
+    },
+  ]);
+});
+
+/**
+ * Initialize a CDP session for a WebSocket connection
+ */
+async function initCDPSession(ws: WebSocket, env: ClawdbotEnv): Promise<void> {
+  let session: CDPSession | null = null;
+
+  try {
+    // Launch browser
+    const browser = await puppeteer.launch(env.BROWSER!);
+    const page = await browser.newPage();
+    const targetId = crypto.randomUUID();
+
+    session = {
+      browser,
+      pages: new Map([[targetId, page]]),
+      defaultTargetId: targetId,
+      nodeIdCounter: 1,
+      nodeMap: new Map(),
+      objectIdCounter: 1,
+      objectMap: new Map(),
+      scriptsToEvaluateOnNewDocument: new Map(),
+      extraHTTPHeaders: new Map(),
+      requestInterceptionEnabled: false,
+      pendingRequests: new Map(),
+    };
+
+    // Send initial target created event
+    sendEvent(ws, 'Target.targetCreated', {
+      targetInfo: {
+        targetId,
+        type: 'page',
+        title: '',
+        url: 'about:blank',
+        attached: true,
+      },
+    });
+
+    console.log('[CDP] Session initialized, targetId:', targetId);
+  } catch (err) {
+    console.error('[CDP] Browser launch failed:', err);
+    ws.close(1011, 'Browser launch failed');
+    return;
+  }
+
+  // Handle incoming messages
+  ws.addEventListener('message', async (event) => {
+    if (!session) return;
+
+    let request: CDPRequest;
+    try {
+      request = JSON.parse(event.data as string);
+    } catch {
+      console.error('[CDP] Invalid JSON received');
+      return;
+    }
+
+    console.log('[CDP] Request:', request.method, request.params);
+
+    try {
+      const result = await handleCDPMethod(session, request.method, request.params || {}, ws);
+      sendResponse(ws, request.id, result);
+    } catch (err) {
+      console.error('[CDP] Method error:', request.method, err);
+      sendError(ws, request.id, -32000, err instanceof Error ? err.message : 'Unknown error');
+    }
+  });
+
+  // Handle close
+  ws.addEventListener('close', async () => {
+    console.log('[CDP] WebSocket closed, cleaning up');
+    if (session) {
+      try {
+        await session.browser.close();
+      } catch (err) {
+        console.error('[CDP] Error closing browser:', err);
+      }
+    }
+  });
+
+  ws.addEventListener('error', (event) => {
+    console.error('[CDP] WebSocket error:', event);
+  });
+}
+
+/**
+ * Handle a CDP method call
+ */
+async function handleCDPMethod(
+  session: CDPSession,
+  method: string,
+  params: Record<string, unknown>,
+  ws: WebSocket
+): Promise<unknown> {
+  const [domain, command] = method.split('.');
+  
+  // Get the current page (use targetId from params or default)
+  const targetId = (params.targetId as string) || session.defaultTargetId;
+  const page = session.pages.get(targetId);
+
+  switch (domain) {
+    case 'Browser':
+      return handleBrowser(session, command, params);
+    
+    case 'Target':
+      return handleTarget(session, command, params, ws);
+    
+    case 'Page':
+      if (!page) throw new Error(`Target not found: ${targetId}`);
+      return handlePage(session, page, command, params, ws);
+    
+    case 'Runtime':
+      if (!page) throw new Error(`Target not found: ${targetId}`);
+      return handleRuntime(session, page, command, params);
+    
+    case 'DOM':
+      if (!page) throw new Error(`Target not found: ${targetId}`);
+      return handleDOM(session, page, command, params);
+    
+    case 'Input':
+      if (!page) throw new Error(`Target not found: ${targetId}`);
+      return handleInput(page, command, params);
+    
+    case 'Network':
+      return handleNetwork(session, page, command, params);
+    
+    case 'Emulation':
+      if (!page) throw new Error(`Target not found: ${targetId}`);
+      return handleEmulation(page, command, params);
+    
+    case 'Fetch':
+      if (!page) throw new Error(`Target not found: ${targetId}`);
+      return handleFetch(session, page, command, params, ws);
+    
+    default:
+      throw new Error(`Unknown domain: ${domain}`);
+  }
+}
+
+/**
+ * Browser domain handlers
+ */
+async function handleBrowser(
+  session: CDPSession,
+  command: string,
+  _params: Record<string, unknown>
+): Promise<unknown> {
+  switch (command) {
+    case 'getVersion':
+      return {
+        protocolVersion: '1.3',
+        product: 'Cloudflare-Browser-Rendering',
+        revision: 'cloudflare',
+        userAgent: 'Mozilla/5.0 Cloudflare Browser Rendering',
+        jsVersion: 'V8',
+      };
+    
+    case 'close':
+      await session.browser.close();
+      return {};
+    
+    default:
+      throw new Error(`Unknown Browser method: ${command}`);
+  }
+}
+
+/**
+ * Target domain handlers
+ */
+async function handleTarget(
+  session: CDPSession,
+  command: string,
+  params: Record<string, unknown>,
+  ws: WebSocket
+): Promise<unknown> {
+  switch (command) {
+    case 'createTarget': {
+      const url = (params.url as string) || 'about:blank';
+      const page = await session.browser.newPage();
+      const targetId = crypto.randomUUID();
+      
+      session.pages.set(targetId, page);
+      
+      if (url !== 'about:blank') {
+        await page.goto(url);
+      }
+      
+      sendEvent(ws, 'Target.targetCreated', {
+        targetInfo: {
+          targetId,
+          type: 'page',
+          title: await page.title(),
+          url: page.url(),
+          attached: true,
+        },
+      });
+      
+      return { targetId };
+    }
+    
+    case 'closeTarget': {
+      const targetId = params.targetId as string;
+      const page = session.pages.get(targetId);
+      
+      if (!page) {
+        throw new Error(`Target not found: ${targetId}`);
+      }
+      
+      await page.close();
+      session.pages.delete(targetId);
+      
+      sendEvent(ws, 'Target.targetDestroyed', { targetId });
+      
+      return { success: true };
+    }
+    
+    case 'getTargets': {
+      const targets = [];
+      for (const [targetId, page] of session.pages) {
+        targets.push({
+          targetId,
+          type: 'page',
+          title: await page.title(),
+          url: page.url(),
+          attached: true,
+        });
+      }
+      return { targetInfos: targets };
+    }
+    
+    case 'attachToTarget':
+      // Already attached
+      return { sessionId: params.targetId };
+    
+    default:
+      throw new Error(`Unknown Target method: ${command}`);
+  }
+}
+
+/**
+ * Page domain handlers
+ */
+async function handlePage(
+  session: CDPSession,
+  page: Page,
+  command: string,
+  params: Record<string, unknown>,
+  ws: WebSocket
+): Promise<unknown> {
+  switch (command) {
+    case 'navigate': {
+      const url = params.url as string;
+      if (!url) throw new Error('url is required');
+      
+      const response = await page.goto(url, {
+        waitUntil: 'load',
+      });
+      
+      sendEvent(ws, 'Page.frameNavigated', {
+        frame: {
+          id: session.defaultTargetId,
+          url: page.url(),
+          securityOrigin: new URL(page.url()).origin,
+          mimeType: 'text/html',
+        },
+      });
+      
+      sendEvent(ws, 'Page.loadEventFired', {
+        timestamp: Date.now() / 1000,
+      });
+      
+      return {
+        frameId: session.defaultTargetId,
+        loaderId: crypto.randomUUID(),
+        errorText: response?.ok() ? undefined : 'Navigation failed',
+      };
+    }
+    
+    case 'reload': {
+      await page.reload();
+      return {};
+    }
+    
+    case 'getFrameTree': {
+      return {
+        frameTree: {
+          frame: {
+            id: session.defaultTargetId,
+            loaderId: crypto.randomUUID(),
+            url: page.url(),
+            securityOrigin: page.url() ? new URL(page.url()).origin : '',
+            mimeType: 'text/html',
+          },
+          childFrames: [],
+        },
+      };
+    }
+    
+    case 'captureScreenshot': {
+      const format = (params.format as string) || 'png';
+      const quality = params.quality as number | undefined;
+      const clip = params.clip as { x: number; y: number; width: number; height: number } | undefined;
+      
+      const data = await page.screenshot({
+        type: format as 'png' | 'jpeg' | 'webp',
+        encoding: 'base64',
+        quality: format === 'jpeg' ? quality : undefined,
+        clip: clip,
+        fullPage: params.fullPage as boolean | undefined,
+      });
+      
+      return { data };
+    }
+    
+    case 'getLayoutMetrics': {
+      const metrics = await page.evaluate(() => ({
+        width: document.documentElement.scrollWidth,
+        height: document.documentElement.scrollHeight,
+        clientWidth: document.documentElement.clientWidth,
+        clientHeight: document.documentElement.clientHeight,
+      }));
+      
+      return {
+        layoutViewport: {
+          pageX: 0,
+          pageY: 0,
+          clientWidth: metrics.clientWidth,
+          clientHeight: metrics.clientHeight,
+        },
+        visualViewport: {
+          offsetX: 0,
+          offsetY: 0,
+          pageX: 0,
+          pageY: 0,
+          clientWidth: metrics.clientWidth,
+          clientHeight: metrics.clientHeight,
+          scale: 1,
+        },
+        contentSize: {
+          x: 0,
+          y: 0,
+          width: metrics.width,
+          height: metrics.height,
+        },
+      };
+    }
+    
+    case 'bringToFront':
+      await page.bringToFront();
+      return {};
+    
+    case 'setContent': {
+      const html = params.html as string;
+      if (!html) throw new Error('html is required');
+      
+      await page.setContent(html, {
+        waitUntil: (params.waitUntil as 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2') || 'load',
+      });
+      
+      return {};
+    }
+    
+    case 'printToPDF': {
+      const options: Parameters<typeof page.pdf>[0] = {};
+      
+      if (params.landscape) options.landscape = params.landscape as boolean;
+      if (params.displayHeaderFooter) options.displayHeaderFooter = params.displayHeaderFooter as boolean;
+      if (params.printBackground) options.printBackground = params.printBackground as boolean;
+      if (params.scale) options.scale = params.scale as number;
+      if (params.paperWidth) options.width = `${params.paperWidth}in`;
+      if (params.paperHeight) options.height = `${params.paperHeight}in`;
+      if (params.marginTop) options.margin = { ...options.margin, top: `${params.marginTop}in` };
+      if (params.marginBottom) options.margin = { ...options.margin, bottom: `${params.marginBottom}in` };
+      if (params.marginLeft) options.margin = { ...options.margin, left: `${params.marginLeft}in` };
+      if (params.marginRight) options.margin = { ...options.margin, right: `${params.marginRight}in` };
+      if (params.pageRanges) options.pageRanges = params.pageRanges as string;
+      if (params.headerTemplate) options.headerTemplate = params.headerTemplate as string;
+      if (params.footerTemplate) options.footerTemplate = params.footerTemplate as string;
+      if (params.preferCSSPageSize) options.preferCSSPageSize = params.preferCSSPageSize as boolean;
+      
+      const buffer = await page.pdf(options);
+      // Convert to base64
+      const data = typeof buffer === 'string' ? buffer : Buffer.from(buffer).toString('base64');
+      
+      return { data };
+    }
+    
+    case 'addScriptToEvaluateOnNewDocument': {
+      const source = params.source as string;
+      if (!source) throw new Error('source is required');
+      
+      const identifier = crypto.randomUUID();
+      session.scriptsToEvaluateOnNewDocument.set(identifier, source);
+      
+      // Add to the page via evaluateOnNewDocument
+      await page.evaluateOnNewDocument(source);
+      
+      return { identifier };
+    }
+    
+    case 'removeScriptToEvaluateOnNewDocument': {
+      const identifier = params.identifier as string;
+      session.scriptsToEvaluateOnNewDocument.delete(identifier);
+      // Note: Can't actually remove already-added scripts in Puppeteer
+      return {};
+    }
+    
+    case 'handleJavaScriptDialog': {
+      const accept = params.accept as boolean;
+      const promptText = params.promptText as string | undefined;
+      
+      // Puppeteer auto-handles dialogs, but we can configure the page
+      page.on('dialog', async (dialog) => {
+        if (accept) {
+          await dialog.accept(promptText);
+        } else {
+          await dialog.dismiss();
+        }
+      });
+      
+      return {};
+    }
+    
+    case 'stopLoading': {
+      await page.evaluate(() => window.stop());
+      return {};
+    }
+    
+    case 'getNavigationHistory': {
+      const history = await page.evaluate(() => ({
+        currentIndex: window.history.length - 1,
+        entries: [{
+          id: 0,
+          url: window.location.href,
+          userTypedURL: window.location.href,
+          title: document.title,
+          transitionType: 'typed',
+        }],
+      }));
+      
+      return history;
+    }
+    
+    case 'navigateToHistoryEntry': {
+      const entryId = params.entryId as number;
+      // Simple implementation - just go back/forward
+      await page.evaluate((id: number) => {
+        const delta = id - (window.history.length - 1);
+        window.history.go(delta);
+      }, entryId);
+      
+      return {};
+    }
+    
+    case 'setBypassCSP': {
+      const enabled = params.enabled as boolean;
+      await page.setBypassCSP(enabled);
+      return {};
+    }
+    
+    case 'enable':
+    case 'disable':
+      // No-op, events always enabled
+      return {};
+    
+    default:
+      throw new Error(`Unknown Page method: ${command}`);
+  }
+}
+
+/**
+ * Runtime domain handlers
+ */
+async function handleRuntime(
+  session: CDPSession,
+  page: Page,
+  command: string,
+  params: Record<string, unknown>
+): Promise<unknown> {
+  switch (command) {
+    case 'evaluate': {
+      const expression = params.expression as string;
+      if (!expression) throw new Error('expression is required');
+      
+      const returnByValue = params.returnByValue ?? true;
+      const awaitPromise = params.awaitPromise ?? false;
+      
+      try {
+        // Wrap in async IIFE if awaitPromise is true
+        const wrappedExpression = awaitPromise 
+          ? `(async () => { return ${expression}; })()`
+          : expression;
+        
+        const result = await page.evaluate(wrappedExpression);
+        
+        // Store object reference if not returning by value
+        let objectId: string | undefined;
+        if (!returnByValue && result !== null && typeof result === 'object') {
+          objectId = `obj-${session.objectIdCounter++}`;
+          session.objectMap.set(objectId, result);
+        }
+        
+        return {
+          result: {
+            type: typeof result,
+            subtype: Array.isArray(result) ? 'array' : (result === null ? 'null' : undefined),
+            className: result?.constructor?.name,
+            value: returnByValue ? result : undefined,
+            objectId,
+            description: String(result),
+          },
+        };
+      } catch (err) {
+        return {
+          exceptionDetails: {
+            exceptionId: 1,
+            text: err instanceof Error ? err.message : 'Evaluation failed',
+            lineNumber: 0,
+            columnNumber: 0,
+          },
+        };
+      }
+    }
+    
+    case 'callFunctionOn': {
+      const functionDeclaration = params.functionDeclaration as string;
+      const args = (params.arguments as Array<{ value?: unknown; objectId?: string }>) || [];
+      const returnByValue = params.returnByValue ?? true;
+      
+      try {
+        // Resolve object references in arguments
+        const argValues = args.map(a => {
+          if (a.objectId) {
+            return session.objectMap.get(a.objectId);
+          }
+          return a.value;
+        });
+        
+        const fn = new Function(`return (${functionDeclaration}).apply(this, arguments)`);
+        const result = await page.evaluate(fn as () => unknown, ...argValues);
+        
+        let objectId: string | undefined;
+        if (!returnByValue && result !== null && typeof result === 'object') {
+          objectId = `obj-${session.objectIdCounter++}`;
+          session.objectMap.set(objectId, result);
+        }
+        
+        return {
+          result: {
+            type: typeof result,
+            subtype: Array.isArray(result) ? 'array' : (result === null ? 'null' : undefined),
+            value: returnByValue ? result : undefined,
+            objectId,
+          },
+        };
+      } catch (err) {
+        return {
+          exceptionDetails: {
+            exceptionId: 1,
+            text: err instanceof Error ? err.message : 'Call failed',
+            lineNumber: 0,
+            columnNumber: 0,
+          },
+        };
+      }
+    }
+    
+    case 'getProperties': {
+      const objectId = params.objectId as string;
+      const ownProperties = params.ownProperties ?? true;
+      
+      const obj = session.objectMap.get(objectId);
+      if (!obj || typeof obj !== 'object') {
+        return { result: [] };
+      }
+      
+      const properties: Array<{
+        name: string;
+        value: { type: string; value?: unknown; description?: string };
+        writable?: boolean;
+        configurable?: boolean;
+        enumerable?: boolean;
+        isOwn?: boolean;
+      }> = [];
+      
+      const keys = ownProperties ? Object.getOwnPropertyNames(obj) : Object.keys(obj as object);
+      
+      for (const key of keys) {
+        const value = (obj as Record<string, unknown>)[key];
+        const descriptor = Object.getOwnPropertyDescriptor(obj, key);
+        
+        properties.push({
+          name: key,
+          value: {
+            type: typeof value,
+            value: value,
+            description: String(value),
+          },
+          writable: descriptor?.writable,
+          configurable: descriptor?.configurable,
+          enumerable: descriptor?.enumerable,
+          isOwn: true,
+        });
+      }
+      
+      return { result: properties };
+    }
+    
+    case 'releaseObject': {
+      const objectId = params.objectId as string;
+      session.objectMap.delete(objectId);
+      return {};
+    }
+    
+    case 'releaseObjectGroup': {
+      // Release all objects (simplified - we don't track groups)
+      session.objectMap.clear();
+      return {};
+    }
+    
+    case 'enable':
+    case 'disable':
+      return {};
+    
+    default:
+      throw new Error(`Unknown Runtime method: ${command}`);
+  }
+}
+
+/**
+ * DOM domain handlers
+ */
+async function handleDOM(
+  session: CDPSession,
+  page: Page,
+  command: string,
+  params: Record<string, unknown>
+): Promise<unknown> {
+  switch (command) {
+    case 'getDocument': {
+      const depth = (params.depth as number) ?? 1;
+      
+      // Get basic document structure
+      const doc = await page.evaluate((maxDepth: number) => {
+        function serializeNode(node: Node, currentDepth: number): unknown {
+          const base: Record<string, unknown> = {
+            nodeId: Math.floor(Math.random() * 1000000),
+            nodeType: node.nodeType,
+            nodeName: node.nodeName,
+            localName: node.nodeName.toLowerCase(),
+            nodeValue: node.nodeValue || '',
+          };
+          
+          if (node instanceof Element) {
+            base.attributes = [];
+            for (const attr of node.attributes) {
+              (base.attributes as string[]).push(attr.name, attr.value);
+            }
+            
+            if (currentDepth < maxDepth && node.children.length > 0) {
+              base.children = [];
+              for (const child of node.children) {
+                (base.children as unknown[]).push(serializeNode(child, currentDepth + 1));
+              }
+              base.childNodeCount = node.children.length;
+            } else {
+              base.childNodeCount = node.children.length;
+            }
+          }
+          
+          return base;
+        }
+        
+        return serializeNode(document.documentElement, 0);
+      }, depth);
+      
+      // Create a stable root nodeId
+      const rootNodeId = session.nodeIdCounter++;
+      session.nodeMap.set(rootNodeId, 'html');
+      
+      return {
+        root: {
+          nodeId: rootNodeId,
+          backendNodeId: rootNodeId,
+          nodeType: 9, // Document
+          nodeName: '#document',
+          localName: '',
+          nodeValue: '',
+          childNodeCount: 1,
+          children: [doc],
+          documentURL: page.url(),
+          baseURL: page.url(),
+        },
+      };
+    }
+    
+    case 'querySelector': {
+      const selector = params.selector as string;
+      if (!selector) throw new Error('selector is required');
+      
+      const element = await page.$(selector);
+      if (!element) {
+        return { nodeId: 0 };
+      }
+      
+      const nodeId = session.nodeIdCounter++;
+      session.nodeMap.set(nodeId, selector);
+      
+      return { nodeId };
+    }
+    
+    case 'querySelectorAll': {
+      const selector = params.selector as string;
+      if (!selector) throw new Error('selector is required');
+      
+      const elements = await page.$$(selector);
+      const nodeIds = elements.map((_, i) => {
+        const nodeId = session.nodeIdCounter++;
+        session.nodeMap.set(nodeId, `${selector}:nth-of-type(${i + 1})`);
+        return nodeId;
+      });
+      
+      return { nodeIds };
+    }
+    
+    case 'getOuterHTML': {
+      const nodeId = params.nodeId as number;
+      const selector = session.nodeMap.get(nodeId);
+      
+      if (!selector) {
+        // Try to get document HTML
+        const html = await page.content();
+        return { outerHTML: html };
+      }
+      
+      const html = await page.evaluate((sel: string) => {
+        const el = document.querySelector(sel);
+        return el ? el.outerHTML : '';
+      }, selector);
+      
+      return { outerHTML: html };
+    }
+    
+    case 'getAttributes': {
+      const nodeId = params.nodeId as number;
+      const selector = session.nodeMap.get(nodeId);
+      
+      if (!selector) throw new Error(`Node not found: ${nodeId}`);
+      
+      const attributes = await page.evaluate((sel: string) => {
+        const el = document.querySelector(sel);
+        if (!el) return [];
+        const attrs: string[] = [];
+        for (const attr of el.attributes) {
+          attrs.push(attr.name, attr.value);
+        }
+        return attrs;
+      }, selector);
+      
+      return { attributes };
+    }
+    
+    case 'setAttributeValue': {
+      const nodeId = params.nodeId as number;
+      const name = params.name as string;
+      const value = params.value as string;
+      const selector = session.nodeMap.get(nodeId);
+      
+      if (!selector) throw new Error(`Node not found: ${nodeId}`);
+      
+      await page.evaluate((sel: string, attrName: string, attrValue: string) => {
+        const el = document.querySelector(sel);
+        if (el) el.setAttribute(attrName, attrValue);
+      }, selector, name, value);
+      
+      return {};
+    }
+    
+    case 'focus': {
+      const nodeId = params.nodeId as number;
+      const selector = session.nodeMap.get(nodeId);
+      
+      if (!selector) throw new Error(`Node not found: ${nodeId}`);
+      
+      await page.focus(selector);
+      return {};
+    }
+    
+    case 'getBoxModel': {
+      const nodeId = params.nodeId as number;
+      const selector = session.nodeMap.get(nodeId);
+      
+      if (!selector) throw new Error(`Node not found: ${nodeId}`);
+      
+      const boxModel = await page.evaluate((sel: string) => {
+        const el = document.querySelector(sel);
+        if (!el) return null;
+        
+        const rect = el.getBoundingClientRect();
+        const scrollX = window.scrollX;
+        const scrollY = window.scrollY;
+        
+        // Content box (innermost)
+        const style = window.getComputedStyle(el);
+        const paddingTop = parseFloat(style.paddingTop);
+        const paddingRight = parseFloat(style.paddingRight);
+        const paddingBottom = parseFloat(style.paddingBottom);
+        const paddingLeft = parseFloat(style.paddingLeft);
+        const borderTop = parseFloat(style.borderTopWidth);
+        const borderRight = parseFloat(style.borderRightWidth);
+        const borderBottom = parseFloat(style.borderBottomWidth);
+        const borderLeft = parseFloat(style.borderLeftWidth);
+        
+        const content = {
+          x: rect.left + scrollX + borderLeft + paddingLeft,
+          y: rect.top + scrollY + borderTop + paddingTop,
+          width: rect.width - borderLeft - borderRight - paddingLeft - paddingRight,
+          height: rect.height - borderTop - borderBottom - paddingTop - paddingBottom,
+        };
+        
+        const padding = {
+          x: rect.left + scrollX + borderLeft,
+          y: rect.top + scrollY + borderTop,
+          width: rect.width - borderLeft - borderRight,
+          height: rect.height - borderTop - borderBottom,
+        };
+        
+        const border = {
+          x: rect.left + scrollX,
+          y: rect.top + scrollY,
+          width: rect.width,
+          height: rect.height,
+        };
+        
+        // Margin box
+        const marginTop = parseFloat(style.marginTop);
+        const marginRight = parseFloat(style.marginRight);
+        const marginBottom = parseFloat(style.marginBottom);
+        const marginLeft = parseFloat(style.marginLeft);
+        
+        const margin = {
+          x: rect.left + scrollX - marginLeft,
+          y: rect.top + scrollY - marginTop,
+          width: rect.width + marginLeft + marginRight,
+          height: rect.height + marginTop + marginBottom,
+        };
+        
+        return { content, padding, border, margin };
+      }, selector);
+      
+      if (!boxModel) {
+        throw new Error(`Element not found: ${selector}`);
+      }
+      
+      // Convert to quad format (4 points: top-left, top-right, bottom-right, bottom-left)
+      const toQuad = (box: { x: number; y: number; width: number; height: number }) => [
+        box.x, box.y,
+        box.x + box.width, box.y,
+        box.x + box.width, box.y + box.height,
+        box.x, box.y + box.height,
+      ];
+      
+      return {
+        model: {
+          content: toQuad(boxModel.content),
+          padding: toQuad(boxModel.padding),
+          border: toQuad(boxModel.border),
+          margin: toQuad(boxModel.margin),
+          width: boxModel.border.width,
+          height: boxModel.border.height,
+        },
+      };
+    }
+    
+    case 'scrollIntoViewIfNeeded': {
+      const nodeId = params.nodeId as number;
+      const selector = session.nodeMap.get(nodeId);
+      
+      if (!selector) throw new Error(`Node not found: ${nodeId}`);
+      
+      await page.evaluate((sel: string) => {
+        const el = document.querySelector(sel);
+        if (el) {
+          el.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+        }
+      }, selector);
+      
+      return {};
+    }
+    
+    case 'removeNode': {
+      const nodeId = params.nodeId as number;
+      const selector = session.nodeMap.get(nodeId);
+      
+      if (!selector) throw new Error(`Node not found: ${nodeId}`);
+      
+      await page.evaluate((sel: string) => {
+        const el = document.querySelector(sel);
+        if (el && el.parentNode) {
+          el.parentNode.removeChild(el);
+        }
+      }, selector);
+      
+      session.nodeMap.delete(nodeId);
+      return {};
+    }
+    
+    case 'setNodeValue': {
+      const nodeId = params.nodeId as number;
+      const value = params.value as string;
+      const selector = session.nodeMap.get(nodeId);
+      
+      if (!selector) throw new Error(`Node not found: ${nodeId}`);
+      
+      await page.evaluate((sel: string, val: string) => {
+        const el = document.querySelector(sel);
+        if (el) {
+          el.textContent = val;
+        }
+      }, selector, value);
+      
+      return {};
+    }
+    
+    case 'setFileInputFiles': {
+      const nodeId = params.nodeId as number;
+      const files = params.files as string[];
+      const selector = session.nodeMap.get(nodeId);
+      
+      if (!selector) throw new Error(`Node not found: ${nodeId}`);
+      
+      const element = await page.$(selector);
+      if (element) {
+        // Cast to input element handle for uploadFile
+        const inputElement = element as unknown as { uploadFile: (...paths: string[]) => Promise<void> };
+        await inputElement.uploadFile(...files);
+      }
+      
+      return {};
+    }
+    
+    case 'enable':
+    case 'disable':
+      return {};
+    
+    default:
+      throw new Error(`Unknown DOM method: ${command}`);
+  }
+}
+
+/**
+ * Input domain handlers
+ */
+async function handleInput(
+  page: Page,
+  command: string,
+  params: Record<string, unknown>
+): Promise<unknown> {
+  switch (command) {
+    case 'dispatchMouseEvent': {
+      const type = params.type as string;
+      const x = params.x as number;
+      const y = params.y as number;
+      const button = (params.button as string) || 'left';
+      const clickCount = (params.clickCount as number) || 1;
+      
+      const mouse = page.mouse;
+      
+      switch (type) {
+        case 'mousePressed':
+          await mouse.down({ button: button as 'left' | 'right' | 'middle' });
+          break;
+        case 'mouseReleased':
+          await mouse.up({ button: button as 'left' | 'right' | 'middle' });
+          break;
+        case 'mouseMoved':
+          await mouse.move(x, y);
+          break;
+        case 'mouseWheel':
+          await mouse.wheel({ deltaX: params.deltaX as number, deltaY: params.deltaY as number });
+          break;
+        default:
+          // For click, do move + down + up
+          await mouse.click(x, y, { 
+            button: button as 'left' | 'right' | 'middle',
+            clickCount,
+          });
+      }
+      
+      return {};
+    }
+    
+    case 'dispatchKeyEvent': {
+      const type = params.type as string;
+      const key = params.key as string;
+      const text = params.text as string;
+      
+      const keyboard = page.keyboard;
+      
+      // Type assertion needed as CDP uses string keys while Puppeteer uses KeyInput
+      type KeyInput = Parameters<typeof keyboard.down>[0];
+      
+      switch (type) {
+        case 'keyDown':
+          await keyboard.down(key as KeyInput);
+          break;
+        case 'keyUp':
+          await keyboard.up(key as KeyInput);
+          break;
+        case 'char':
+          if (text) await keyboard.type(text);
+          break;
+        default:
+          if (key) await keyboard.press(key as KeyInput);
+      }
+      
+      return {};
+    }
+    
+    case 'insertText': {
+      const text = params.text as string;
+      if (text) {
+        await page.keyboard.type(text);
+      }
+      return {};
+    }
+    
+    default:
+      throw new Error(`Unknown Input method: ${command}`);
+  }
+}
+
+/**
+ * Network domain handlers
+ */
+async function handleNetwork(
+  session: CDPSession,
+  page: Page | undefined,
+  command: string,
+  params: Record<string, unknown>
+): Promise<unknown> {
+  switch (command) {
+    case 'enable':
+    case 'disable':
+      // Network events not fully supported, no-op
+      return {};
+    
+    case 'setCacheDisabled': {
+      if (page) {
+        await page.setCacheEnabled(!(params.cacheDisabled as boolean));
+      }
+      return {};
+    }
+    
+    case 'setExtraHTTPHeaders': {
+      const headers = params.headers as Record<string, string>;
+      
+      // Store headers in session
+      session.extraHTTPHeaders.clear();
+      for (const [name, value] of Object.entries(headers)) {
+        session.extraHTTPHeaders.set(name, value);
+      }
+      
+      // Apply to page
+      if (page) {
+        await page.setExtraHTTPHeaders(headers);
+      }
+      
+      return {};
+    }
+    
+    case 'setCookie': {
+      if (!page) throw new Error('No page available');
+      
+      const cookie = {
+        name: params.name as string,
+        value: params.value as string,
+        url: params.url as string | undefined,
+        domain: params.domain as string | undefined,
+        path: params.path as string | undefined,
+        secure: params.secure as boolean | undefined,
+        httpOnly: params.httpOnly as boolean | undefined,
+        sameSite: params.sameSite as 'Strict' | 'Lax' | 'None' | undefined,
+        expires: params.expires as number | undefined,
+      };
+      
+      await page.setCookie(cookie);
+      
+      return { success: true };
+    }
+    
+    case 'setCookies': {
+      if (!page) throw new Error('No page available');
+      
+      const cookies = params.cookies as Array<{
+        name: string;
+        value: string;
+        url?: string;
+        domain?: string;
+        path?: string;
+        secure?: boolean;
+        httpOnly?: boolean;
+        sameSite?: 'Strict' | 'Lax' | 'None';
+        expires?: number;
+      }>;
+      
+      await page.setCookie(...cookies);
+      
+      return {};
+    }
+    
+    case 'getCookies': {
+      if (!page) throw new Error('No page available');
+      
+      const urls = params.urls as string[] | undefined;
+      const cookies = await page.cookies(...(urls || []));
+      
+      return {
+        cookies: cookies.map(c => ({
+          name: c.name,
+          value: c.value,
+          domain: c.domain,
+          path: c.path,
+          expires: c.expires,
+          size: c.name.length + c.value.length,
+          httpOnly: c.httpOnly,
+          secure: c.secure,
+          session: c.session,
+          sameSite: c.sameSite,
+        })),
+      };
+    }
+    
+    case 'deleteCookies': {
+      if (!page) throw new Error('No page available');
+      
+      const name = params.name as string;
+      const url = params.url as string | undefined;
+      const domain = params.domain as string | undefined;
+      const path = params.path as string | undefined;
+      
+      await page.deleteCookie({
+        name,
+        url,
+        domain,
+        path,
+      });
+      
+      return {};
+    }
+    
+    case 'clearBrowserCookies': {
+      if (!page) throw new Error('No page available');
+      
+      // Get all cookies and delete them
+      const cookies = await page.cookies();
+      for (const cookie of cookies) {
+        await page.deleteCookie(cookie);
+      }
+      
+      return {};
+    }
+    
+    case 'setUserAgentOverride': {
+      if (!page) throw new Error('No page available');
+      
+      const userAgent = params.userAgent as string;
+      await page.setUserAgent(userAgent);
+      
+      return {};
+    }
+    
+    default:
+      throw new Error(`Unknown Network method: ${command}`);
+  }
+}
+
+/**
+ * Emulation domain handlers
+ */
+async function handleEmulation(
+  page: Page,
+  command: string,
+  params: Record<string, unknown>
+): Promise<unknown> {
+  switch (command) {
+    case 'setDeviceMetricsOverride': {
+      const width = params.width as number;
+      const height = params.height as number;
+      const deviceScaleFactor = (params.deviceScaleFactor as number) || 1;
+      const mobile = (params.mobile as boolean) || false;
+      
+      await page.setViewport({
+        width,
+        height,
+        deviceScaleFactor,
+        isMobile: mobile,
+      });
+      
+      return {};
+    }
+    
+    case 'setUserAgentOverride': {
+      const userAgent = params.userAgent as string;
+      await page.setUserAgent(userAgent);
+      return {};
+    }
+    
+    case 'clearDeviceMetricsOverride':
+      // Reset to default
+      await page.setViewport({ width: 1280, height: 720 });
+      return {};
+    
+    case 'setGeolocationOverride': {
+      const latitude = params.latitude as number | undefined;
+      const longitude = params.longitude as number | undefined;
+      const accuracy = params.accuracy as number | undefined;
+      
+      if (latitude !== undefined && longitude !== undefined) {
+        await page.setGeolocation({
+          latitude,
+          longitude,
+          accuracy: accuracy ?? 100,
+        });
+      }
+      
+      return {};
+    }
+    
+    case 'clearGeolocationOverride': {
+      // Can't truly clear, but we can set to a default
+      return {};
+    }
+    
+    case 'setTimezoneOverride': {
+      const timezoneId = params.timezoneId as string;
+      
+      // Puppeteer doesn't have direct timezone override, but we can emulate via evaluate
+      await page.evaluateOnNewDocument((tz: string) => {
+        // Override Date to use the specified timezone
+        const originalDate = Date;
+        const originalToString = Date.prototype.toString;
+        const originalToLocaleString = Date.prototype.toLocaleString;
+        
+        Date.prototype.toString = function() {
+          return originalToLocaleString.call(this, 'en-US', { timeZone: tz });
+        };
+        
+        // Store timezone for scripts that check it
+        (globalThis as unknown as Record<string, string>).__timezone = tz;
+      }, timezoneId);
+      
+      return {};
+    }
+    
+    case 'setTouchEmulationEnabled': {
+      const enabled = params.enabled as boolean;
+      
+      // Puppeteer handles this via viewport isMobile, but we can also inject touch events
+      if (enabled) {
+        await page.evaluateOnNewDocument(() => {
+          // Make the browser think it supports touch
+          Object.defineProperty(navigator, 'maxTouchPoints', {
+            get: () => 1,
+          });
+          
+          // Add touch event support indicator
+          window.ontouchstart = null;
+        });
+      }
+      
+      return {};
+    }
+    
+    case 'setEmulatedMedia': {
+      const media = params.media as string | undefined;
+      const features = params.features as Array<{ name: string; value: string }> | undefined;
+      
+      if (media) {
+        await page.emulateMediaType(media as 'screen' | 'print');
+      }
+      
+      if (features) {
+        const featureObj: Record<string, string> = {};
+        for (const f of features) {
+          featureObj[f.name] = f.value;
+        }
+        await page.emulateMediaFeatures(
+          features.map(f => ({ name: f.name, value: f.value }))
+        );
+      }
+      
+      return {};
+    }
+    
+    case 'setDefaultBackgroundColorOverride': {
+      const color = params.color as { r: number; g: number; b: number; a?: number } | undefined;
+      
+      if (color) {
+        const { r, g, b, a = 1 } = color;
+        await page.evaluate((rgba: string) => {
+          document.documentElement.style.backgroundColor = rgba;
+        }, `rgba(${r}, ${g}, ${b}, ${a})`);
+      }
+      
+      return {};
+    }
+    
+    default:
+      throw new Error(`Unknown Emulation method: ${command}`);
+  }
+}
+
+/**
+ * Fetch domain handlers (request interception)
+ */
+async function handleFetch(
+  session: CDPSession,
+  page: Page,
+  command: string,
+  params: Record<string, unknown>,
+  ws: WebSocket
+): Promise<unknown> {
+  switch (command) {
+    case 'enable': {
+      const patterns = params.patterns as Array<{ urlPattern?: string; requestStage?: string }> | undefined;
+      
+      session.requestInterceptionEnabled = true;
+      
+      // Set up request interception
+      await page.setRequestInterception(true);
+      
+      page.on('request', async (request) => {
+        if (!session.requestInterceptionEnabled) {
+          await request.continue();
+          return;
+        }
+        
+        const requestId = crypto.randomUUID();
+        
+        // Check if request matches patterns
+        let shouldIntercept = !patterns || patterns.length === 0;
+        if (patterns) {
+          for (const pattern of patterns) {
+            if (!pattern.urlPattern || request.url().match(pattern.urlPattern)) {
+              shouldIntercept = true;
+              break;
+            }
+          }
+        }
+        
+        if (shouldIntercept) {
+          // Store the request for later handling
+          session.pendingRequests.set(requestId, {
+            request: request as unknown as Request,
+            resolve: () => {},
+          });
+          
+          // Send Fetch.requestPaused event
+          sendEvent(ws, 'Fetch.requestPaused', {
+            requestId,
+            request: {
+              url: request.url(),
+              method: request.method(),
+              headers: request.headers(),
+              postData: request.postData(),
+            },
+            frameId: session.defaultTargetId,
+            resourceType: request.resourceType(),
+          });
+        } else {
+          await request.continue();
+        }
+      });
+      
+      return {};
+    }
+    
+    case 'disable': {
+      session.requestInterceptionEnabled = false;
+      await page.setRequestInterception(false);
+      return {};
+    }
+    
+    case 'continueRequest': {
+      const requestId = params.requestId as string;
+      const url = params.url as string | undefined;
+      const method = params.method as string | undefined;
+      const postData = params.postData as string | undefined;
+      const headers = params.headers as Array<{ name: string; value: string }> | undefined;
+      
+      const pending = session.pendingRequests.get(requestId);
+      if (!pending) {
+        throw new Error(`Request not found: ${requestId}`);
+      }
+      
+      const request = pending.request as unknown as { continue: (opts?: Record<string, unknown>) => Promise<void> };
+      
+      const overrides: Record<string, unknown> = {};
+      if (url) overrides.url = url;
+      if (method) overrides.method = method;
+      if (postData) overrides.postData = postData;
+      if (headers) {
+        overrides.headers = headers.reduce((acc, h) => {
+          acc[h.name] = h.value;
+          return acc;
+        }, {} as Record<string, string>);
+      }
+      
+      await request.continue(Object.keys(overrides).length > 0 ? overrides : undefined);
+      session.pendingRequests.delete(requestId);
+      
+      return {};
+    }
+    
+    case 'fulfillRequest': {
+      const requestId = params.requestId as string;
+      const responseCode = params.responseCode as number;
+      const responseHeaders = params.responseHeaders as Array<{ name: string; value: string }> | undefined;
+      const body = params.body as string | undefined;
+      
+      const pending = session.pendingRequests.get(requestId);
+      if (!pending) {
+        throw new Error(`Request not found: ${requestId}`);
+      }
+      
+      const request = pending.request as unknown as { respond: (opts: Record<string, unknown>) => Promise<void> };
+      
+      const headers: Record<string, string> = {};
+      if (responseHeaders) {
+        for (const h of responseHeaders) {
+          headers[h.name] = h.value;
+        }
+      }
+      
+      await request.respond({
+        status: responseCode,
+        headers,
+        body: body ? Buffer.from(body, 'base64') : undefined,
+      });
+      
+      session.pendingRequests.delete(requestId);
+      
+      return {};
+    }
+    
+    case 'failRequest': {
+      const requestId = params.requestId as string;
+      const errorReason = params.errorReason as string;
+      
+      const pending = session.pendingRequests.get(requestId);
+      if (!pending) {
+        throw new Error(`Request not found: ${requestId}`);
+      }
+      
+      const request = pending.request as unknown as { abort: (reason?: string) => Promise<void> };
+      
+      // Map CDP error reasons to Puppeteer abort reasons
+      const abortReason = errorReason.toLowerCase().includes('access') ? 'accessdenied' :
+                         errorReason.toLowerCase().includes('address') ? 'addressunreachable' :
+                         errorReason.toLowerCase().includes('blocked') ? 'blockedbyclient' :
+                         errorReason.toLowerCase().includes('connection') ? 'connectionfailed' :
+                         errorReason.toLowerCase().includes('timeout') ? 'timedout' :
+                         'failed';
+      
+      await request.abort(abortReason);
+      session.pendingRequests.delete(requestId);
+      
+      return {};
+    }
+    
+    case 'getResponseBody': {
+      // This would need to store response bodies, which we're not currently doing
+      // Return empty for now
+      return { body: '', base64Encoded: false };
+    }
+    
+    default:
+      throw new Error(`Unknown Fetch method: ${command}`);
+  }
+}
+
+/**
+ * Send a CDP response
+ */
+function sendResponse(ws: WebSocket, id: number, result: unknown): void {
+  const response: CDPResponse = { id, result };
+  ws.send(JSON.stringify(response));
+}
+
+/**
+ * Send a CDP error
+ */
+function sendError(ws: WebSocket, id: number, code: number, message: string): void {
+  const response: CDPResponse = { id, error: { code, message } };
+  ws.send(JSON.stringify(response));
+}
+
+/**
+ * Send a CDP event
+ */
+function sendEvent(ws: WebSocket, method: string, params?: Record<string, unknown>): void {
+  const event: CDPEvent = { method, params };
+  ws.send(JSON.stringify(event));
+}
+
+/**
+ * Constant-time string comparison to prevent timing attacks
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}
+
+export { cdp };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,3 +1,4 @@
 export { api } from './api';
 export { admin } from './admin';
 export { debug } from './debug';
+export { cdp } from './cdp';

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,10 @@ export interface ClawdbotEnv {
   R2_ACCESS_KEY_ID?: string;
   R2_SECRET_ACCESS_KEY?: string;
   CF_ACCOUNT_ID?: string; // Cloudflare account ID for R2 endpoint
+  // Browser Rendering binding for CDP shim
+  BROWSER?: Fetcher;
+  CDP_SECRET?: string; // Shared secret for CDP endpoint authentication
+  WORKER_URL?: string; // Public URL of the worker (for CDP endpoint)
 }
 
 /**

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -60,6 +60,10 @@
   "triggers": {
     "crons": ["*/5 * * * *"],
   },
+  // Browser Rendering binding for CDP shim
+  "browser": {
+    "binding": "BROWSER",
+  },
   "vars": {
     "CF_ACCOUNT_ID": "d6d80af9d563479dd9d01a10c3c3a37a",
   },
@@ -72,6 +76,7 @@
   // - SLACK_BOT_TOKEN: (optional) Slack bot token
   // - SLACK_APP_TOKEN: (optional) Slack app token
   // - CLAWDBOT_GATEWAY_TOKEN: (optional) Token to protect gateway access, if unset device pairing will be used
+  // - CDP_SECRET: (optional) Shared secret for /cdp endpoint authentication
   //
   // R2 persistent storage secrets (required for data persistence across sessions):
   // - AWS_ACCESS_KEY_ID: R2 access key ID (from R2 API tokens)


### PR DESCRIPTION
Implements a CDP (Chrome DevTools Protocol) WebSocket shim that translates CDP commands to Cloudflare Browser Rendering binding calls.

Key features:
- WebSocket endpoint at /cdp for raw CDP protocol
- HTTP discovery endpoints for Moltbot/Playwright compatibility:
  - GET /cdp/json/version - returns browser info and webSocketDebuggerUrl
  - GET /cdp/json/list - returns list of available targets
  - GET /cdp/json - alias for /json/list
- Authentication via shared secret (CDP_SECRET) in query param
- Supports CDP domains: Browser, Target, Page, Runtime, DOM, Input, Network, Emulation, and Fetch (request interception)

This allows Moltbot to use the worker as a remote CDP browser profile:
  browser.profiles.cloudflare.cdpUrl = 'https://worker.dev/cdp?secret=...'