### PR TITLE
Auto-generate CDP secret and simplify browser automation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,22 @@ npx wrangler secret put SLACK_APP_TOKEN
 npm run deploy
 ```
 
+## Optional: Browser Automation (CDP)
+
+This worker includes a Chrome DevTools Protocol (CDP) shim that enables browser automation capabilities. This allows Moltbot to control a headless browser for tasks like web scraping, screenshots, and automated testing.
+
+### Setup
+
+The CDP shim is enabled by default. You'll need to set up a bypass for the `/cdp/*` routes in Cloudflare Access to allow Moltbot to access the CDP endpoints.
+As part of setup, we generate a secondary secret for CDP authentication to protect these routes independent of the main Cloudflare Access JWT. 
+
+If you followed the Cloudflare Access setup instructions in the previous section, you can do this by:
+
+1. Navigate to the Settings page of your worker on the Cloudflare dashboard
+2. Select the "Manage Cloudflare Access" option in the menu next to the "workers.dev" domain
+3. Find your Access applicaiton in the list and select "Edit"
+4. Change the "Path" field in the Public Hostname section to `^(?!cdp).*` to allow the cdp paths to bypass Cloudflare Access.
+
 ## Built-in Skills
 
 The container includes pre-installed skills in `/root/clawd/skills/`:


### PR DESCRIPTION
## Summary

- Auto-generate `CDP_SECRET` from `MOLTBOT_GATEWAY_TOKEN` using SHA-256 hash derivation
- Auto-derive `WORKER_URL` from the incoming request host
- Simplify browser automation setup - users just need to configure CF Access bypass for `/cdp/*` routes

## Changes

- **`src/config.ts`**: Added `generateCDPSecret()` function that derives a deterministic 64-char hex secret from the gateway token
- **`src/gateway/env.ts`**: Now async; generates CDP secret when BROWSER binding is present; accepts `workerUrl` option
- **`src/gateway/process.ts`**: Updated to pass worker URL from request context to container
- **`src/index.ts`**: Derives worker URL from request and passes to `ensureMoltbotGateway()`
- **`src/routes/cdp.ts`**: Uses `getExpectedCDPSecret()` helper instead of reading from env
- **`src/types.ts`**: Removed `CDP_SECRET` and `WORKER_URL` from user-configurable secrets
- **`README.md`**: Updated Browser Automation setup to explain CF Access bypass configuration using path regex `^(?!cdp).*`

## Why

Users previously had to manually set `CDP_SECRET` and `WORKER_URL` to use browser automation. Since these are only used for internal communication between the worker and moltbot container, there's no reason to require manual configuration. The secret is derived deterministically so both sides compute the same value.

The `/cdp/*` routes bypass CF Access and instead use the auto-generated shared secret for authentication, allowing moltbot inside the container to access the CDP endpoints.