### PR TITLE
Rename dm.policy to dmPolicy in Telegram config

### DIFF
--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -188,7 +188,7 @@ if (process.env.TELEGRAM_BOT_TOKEN) {
     config.channels.telegram.botToken = process.env.TELEGRAM_BOT_TOKEN;
     config.channels.telegram.enabled = true;
     config.channels.telegram.dm = config.channels.telegram.dm || {};
-    config.channels.telegram.dm.policy = process.env.TELEGRAM_DM_POLICY || 'pairing';
+    config.channels.telegram.dmPolicy = process.env.TELEGRAM_DM_POLICY || 'pairing';
 }
 
 // Discord configuration


### PR DESCRIPTION
The correct config is  dmPolicy
https://docs.molt.bot/channels/telegram#:~:text=from%20file%20path.-,channels.telegram.dmPolicy,-%3A%20pairing%20%7C%20allowlist