### PR TITLE
URL safe token

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npx wrangler secret put ANTHROPIC_API_KEY
 
 # Generate and set a gateway token (required for remote access)
 # Save this token - you'll need it to access the Control UI
-export MOLTBOT_GATEWAY_TOKEN=$(openssl rand -base64 32 | tr -d '=+/' | head -c 32)
+export MOLTBOT_GATEWAY_TOKEN=$(openssl rand -hex 32)
 echo "Your gateway token: $MOLTBOT_GATEWAY_TOKEN"
 echo "$MOLTBOT_GATEWAY_TOKEN" | npx wrangler secret put MOLTBOT_GATEWAY_TOKEN
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "description": "Your [Anthropic API key](https://console.anthropic.com/)."
       },
       "MOLTBOT_GATEWAY_TOKEN": {
-        "description": "Token to protect gateway access. Random string, you can generate one with `openssl rand -base64 32`, for example."
+        "description": "Token for gateway access. Generate with: openssl rand -hex 32"
       }
     }
   }


### PR DESCRIPTION
Should fix https://github.com/cloudflare/moltworker/issues/38

Note -hex 32 is pretty long e.g.

```
openssl rand -hex 32
72e7a5ad36974b23b9492742cfcaa6e7d3e558455c382f4f01175ceb7a131fef
```

22 is closer to the original
```
openssl rand -hex 22
1c4af718c8d6fce7b25f6f627cff877d70100bb7aa78
```