### PR TITLE
fix: Remove initialization of invalid "dm" config for Telegram

### DIFF
--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -187,7 +187,6 @@ if (process.env.TELEGRAM_BOT_TOKEN) {
     config.channels.telegram = config.channels.telegram || {};
     config.channels.telegram.botToken = process.env.TELEGRAM_BOT_TOKEN;
     config.channels.telegram.enabled = true;
-    config.channels.telegram.dm = config.channels.telegram.dm || {};
     config.channels.telegram.dmPolicy = process.env.TELEGRAM_DM_POLICY || 'pairing';
 }
 


### PR DESCRIPTION
Remove initialization of invalid "dm" config for Telegram. When adding a `TELEGRAM_BOT_TOKEN` service is currently erroring with: 

```
Config invalid File: ~/.clawdbot/clawdbot.json Problem: - channels.telegram: Unrecognized key: "dm"
```

see MoltBot Docs: https://docs.molt.bot/channels/telegram#2-configure-the-token-env-or-config

Closes [issue 57 ](https://github.com/cloudflare/moltworker/issues/57)