### PR TITLE
fix: Dockerfile supports arm64 Node download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,14 @@ FROM docker.io/cloudflare/sandbox:0.7.0
 # The base image has Node 20, we need to replace it with Node 22
 # Using direct binary download for reliability
 ENV NODE_VERSION=22.13.1
-RUN apt-get update && apt-get install -y xz-utils ca-certificates rsync \
-    && curl -fsSLk https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz -o /tmp/node.tar.xz \
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "${ARCH}" in \
+         amd64) NODE_ARCH="x64" ;; \
+         arm64) NODE_ARCH="arm64" ;; \
+         *) echo "Unsupported architecture: ${ARCH}" >&2; exit 1 ;; \
+       esac \
+    && apt-get update && apt-get install -y xz-utils ca-certificates rsync \
+    && curl -fsSLk https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz -o /tmp/node.tar.xz \
     && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
     && rm /tmp/node.tar.xz \
     && node --version \


### PR DESCRIPTION
## Summary

The Dockerfile previously hardcoded `linux-x64` in the Node.js binary download URL. On arm64 hosts this can lead to an `exec format error` during the image build.

This change selects the correct Node.js tarball based on `dpkg --print-architecture`:

- `amd64` -> `linux-x64`
- `arm64` -> `linux-arm64`

Unsupported architectures fail fast with a clear error.

## Test plan

- [ ] Build on amd64: `docker build -t moltworker-test .`
- [ ] Build on arm64: `docker build -t moltworker-test .`
- [ ] Verify `node --version` succeeds in the built image
