### PR TITLE
feat: persist full workspace to R2, not just skills

### DIFF
--- a/src/gateway/sync.ts
+++ b/src/gateway/sync.ts
@@ -12,13 +12,18 @@ export interface SyncResult {
 }
 
 /**
- * Sync moltbot config from container to R2 for persistence.
+ * Sync moltbot config and workspace from container to R2 for persistence.
  * 
  * This function:
  * 1. Mounts R2 if not already mounted
  * 2. Verifies source has critical files (prevents overwriting good backup with empty data)
- * 3. Runs rsync to copy config to R2
+ * 3. Runs rsync to copy config and workspace to R2
  * 4. Writes a timestamp file for tracking
+ * 
+ * Persisted paths:
+ * - /root/.clawdbot/ -> R2/clawdbot/ (config, cron, credentials)
+ * - /root/clawd/     -> R2/clawd/    (workspace: memory, tools, custom files)
+ * - /root/clawd/skills/ -> R2/skills/ (legacy path for backwards compatibility)
  * 
  * @param sandbox - The sandbox instance
  * @param env - Worker environment bindings
@@ -57,9 +62,13 @@ export async function syncToR2(sandbox: Sandbox, env: MoltbotEnv): Promise<SyncR
     };
   }
 
-  // Run rsync to backup config to R2
+  // Run rsync to backup config and workspace to R2
   // Note: Use --no-times because s3fs doesn't support setting timestamps
-  const syncCmd = `rsync -r --no-times --delete --exclude='*.lock' --exclude='*.log' --exclude='*.tmp' /root/.clawdbot/ ${R2_MOUNT_PATH}/clawdbot/ && rsync -r --no-times --delete /root/clawd/skills/ ${R2_MOUNT_PATH}/skills/ && date -Iseconds > ${R2_MOUNT_PATH}/.last-sync`;
+  // Syncs:
+  //   /root/.clawdbot/ -> R2/clawdbot/     (config, cron, credentials)
+  //   /root/clawd/     -> R2/clawd/        (workspace: memory, tools, skills, etc.)
+  //   /root/clawd/skills/ -> R2/skills/    (legacy: kept for backwards compatibility)
+  const syncCmd = `rsync -r --no-times --delete --exclude='*.lock' --exclude='*.log' --exclude='*.tmp' /root/.clawdbot/ ${R2_MOUNT_PATH}/clawdbot/ && rsync -r --no-times --delete --exclude='*.lock' --exclude='*.log' --exclude='*.tmp' --exclude='.git' --exclude='node_modules' /root/clawd/ ${R2_MOUNT_PATH}/clawd/ && rsync -r --no-times --delete /root/clawd/skills/ ${R2_MOUNT_PATH}/skills/ && date -Iseconds > ${R2_MOUNT_PATH}/.last-sync`;
   
   try {
     const proc = await sandbox.startProcess(syncCmd);

--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -94,11 +94,25 @@ else
     echo "R2 not mounted, starting fresh"
 fi
 
-# Restore skills from R2 backup if available (only if R2 is newer)
+# Restore full workspace from R2 backup if available (only if R2 is newer)
+# This includes memory, tools, custom files - everything the agent creates
+WORKSPACE_DIR="/root/clawd"
+if [ -d "$BACKUP_DIR/clawd" ] && [ "$(ls -A $BACKUP_DIR/clawd 2>/dev/null)" ]; then
+    if should_restore_from_r2; then
+        echo "Restoring workspace from $BACKUP_DIR/clawd..."
+        mkdir -p "$WORKSPACE_DIR"
+        cp -a "$BACKUP_DIR/clawd/." "$WORKSPACE_DIR/"
+        echo "Restored workspace from R2 backup"
+    fi
+fi
+
+# Restore skills from R2 backup if available (legacy path, only if R2 is newer)
+# Note: Skills are also included in the workspace backup above, but we keep this
+# for backwards compatibility with existing backups that only have /skills/
 SKILLS_DIR="/root/clawd/skills"
 if [ -d "$BACKUP_DIR/skills" ] && [ "$(ls -A $BACKUP_DIR/skills 2>/dev/null)" ]; then
     if should_restore_from_r2; then
-        echo "Restoring skills from $BACKUP_DIR/skills..."
+        echo "Restoring skills from $BACKUP_DIR/skills (legacy path)..."
         mkdir -p "$SKILLS_DIR"
         cp -a "$BACKUP_DIR/skills/." "$SKILLS_DIR/"
         echo "Restored skills from R2 backup"


### PR DESCRIPTION
## Problem

Currently, only `/root/.clawdbot/` and `/root/clawd/skills/` are synced to R2 for persistence. This means agent workspace files are lost on container restart:

- `memory/` (agent memory/notes)
- `TOOLS.md` (local tool configuration)
- `tov/` (tone of voice docs)
- Any other custom directories the agent creates

This is particularly painful for agents that rely on persistent memory across sessions.

## Solution

Add the full workspace (`/root/clawd/`) to the R2 sync:

**sync.ts:**
- Added rsync for `/root/clawd/` → `R2/clawd/`
- Excludes `.git`, `node_modules`, and temp files

**start-moltbot.sh:**
- Added restore logic for workspace from `R2/clawd/`
- Workspace restore runs before the legacy skills restore

## Backwards Compatibility

The legacy `/skills/` path is preserved for backwards compatibility with existing R2 backups that only have the skills directory.

## Testing

1. Deploy with this change
2. Create files in `/root/clawd/` (e.g., `memory/test.md`)
3. Wait for sync (5 min cron) or trigger manually
4. Restart container
5. Verify files are restored

Fixes agent memory loss on container restart.