### PR TITLE
feat: run clawdbot doctor --fix on startup to self-heal config

### DIFF
--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -275,6 +275,11 @@ EOFNODE
 # START GATEWAY
 # ============================================================
 # Note: R2 backup sync is handled by the Worker's cron trigger
+
+# Auto-heal config by stripping unrecognized keys (self-heals on schema changes)
+echo "Running config doctor to validate and fix configuration..."
+clawdbot doctor --fix || echo "Warning: doctor --fix failed, continuing anyway"
+
 echo "Starting Moltbot Gateway..."
 echo "Gateway will be available on port 18789"
 


### PR DESCRIPTION
## Summary
- Adds `clawdbot doctor --fix` before gateway startup to auto-strip unrecognized config keys
- Makes boot resilient to schema changes after clawdbot upgrades
- Includes fallback so gateway still starts if doctor fails

## Test plan
- [ ] Deploy to sandbox and verify gateway starts successfully
- [ ] Check logs show "Running config doctor to validate and fix configuration..."
- [ ] Introduce an invalid key in config and verify it gets stripped on next boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)