### PR TITLE
Remove telegram.dm field in start-moltbot.sh to fix unrecognized fiel…

### DIFF
--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -187,7 +187,6 @@ if (process.env.TELEGRAM_BOT_TOKEN) {
     config.channels.telegram = config.channels.telegram || {};
     config.channels.telegram.botToken = process.env.TELEGRAM_BOT_TOKEN;
     config.channels.telegram.enabled = true;
-    config.channels.telegram.dm = config.channels.telegram.dm || {};
     config.channels.telegram.dmPolicy = process.env.TELEGRAM_DM_POLICY || 'pairing';
 }
 


### PR DESCRIPTION
Fixes error
`[Gateway] Failed to get logs: Error: Moltbot gateway failed to start. Stderr: Invalid config at /root/.clawdbot/clawdbot.json:\n- channels.telegram: Unrecognized key: "dm" (node:659) [DEP0040] DeprecationWarning: The punycode module is deprecated. Please use a userland alternative instead. (Use node --trace-deprecation ... to show where the warning was created) Config invalid File: ~/.clawdbot/clawdbot.json Problem: - channels.telegram: Unrecognized key: "dm" Run: clawdbot doctor --fix`