### PR TITLE
feat: upgrade from clawdbot to openclaw@latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/cloudflare/sandbox:0.7.0
 
-# Install Node.js 22 (required by clawdbot) and rsync (for R2 backup sync)
+# Install Node.js 22 (required by openclaw) and rsync (for R2 backup sync)
 # The base image has Node 20, we need to replace it with Node 22
 # Using direct binary download for reliability
 ENV NODE_VERSION=22.13.1
@@ -14,12 +14,11 @@ RUN apt-get update && apt-get install -y xz-utils ca-certificates rsync \
 # Install pnpm globally
 RUN npm install -g pnpm
 
-# Install moltbot (CLI is still named clawdbot until upstream renames)
-# Pin to specific version for reproducible builds
-RUN npm install -g clawdbot@2026.1.24-3 \
-    && clawdbot --version
+# Install openclaw (formerly clawdbot)
+RUN npm install -g openclaw@latest \
+    && openclaw --version
 
-# Create moltbot directories (paths still use clawdbot until upstream renames)
+# Create openclaw directories
 # Templates are stored in /root/.clawdbot-templates for initialization
 RUN mkdir -p /root/.clawdbot \
     && mkdir -p /root/.clawdbot-templates \
@@ -27,7 +26,7 @@ RUN mkdir -p /root/.clawdbot \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-01-28-v26-browser-skill
+# Build cache bust: 2026-02-01-upgrade-to-openclaw
 COPY start-moltbot.sh /usr/local/bin/start-moltbot.sh
 RUN chmod +x /usr/local/bin/start-moltbot.sh
 

--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -8,9 +8,8 @@
 
 set -e
 
-# Check if clawdbot gateway is already running - bail early if so
-# Note: CLI is still named "clawdbot" until upstream renames it
-if pgrep -f "clawdbot gateway" > /dev/null 2>&1; then
+# Check if openclaw gateway is already running - bail early if so
+if pgrep -f "openclaw gateway" > /dev/null 2>&1; then
     echo "Moltbot gateway is already running, exiting."
     exit 0
 fi
@@ -278,7 +277,8 @@ EOFNODE
 echo "Starting Moltbot Gateway..."
 echo "Gateway will be available on port 18789"
 
-# Clean up stale lock files
+# Clean up stale lock files (openclaw uses /tmp/openclaw-<uid>/ directory)
+rm -rf /tmp/openclaw-* 2>/dev/null || true
 rm -f /tmp/clawdbot-gateway.lock 2>/dev/null || true
 rm -f "$CONFIG_DIR/gateway.lock" 2>/dev/null || true
 
@@ -287,8 +287,8 @@ echo "Dev mode: ${CLAWDBOT_DEV_MODE:-false}, Bind mode: $BIND_MODE"
 
 if [ -n "$CLAWDBOT_GATEWAY_TOKEN" ]; then
     echo "Starting gateway with token auth..."
-    exec clawdbot gateway --port 18789 --verbose --allow-unconfigured --bind "$BIND_MODE" --token "$CLAWDBOT_GATEWAY_TOKEN"
+    exec openclaw gateway --port 18789 --verbose --allow-unconfigured --bind "$BIND_MODE" --token "$CLAWDBOT_GATEWAY_TOKEN"
 else
     echo "Starting gateway with device pairing (no token)..."
-    exec clawdbot gateway --port 18789 --verbose --allow-unconfigured --bind "$BIND_MODE"
+    exec openclaw gateway --port 18789 --verbose --allow-unconfigured --bind "$BIND_MODE"
 fi


### PR DESCRIPTION
## Summary
- Switch npm package from `clawdbot@2026.1.24-3` to `openclaw@latest`
- Update CLI commands from `clawdbot` to `openclaw`
- Update lock file cleanup for new openclaw lock directory format
- Keep legacy config paths (`.clawdbot/`, `clawdbot.json`) - openclaw has backward compatibility

## Why @latest?
The project is moving fast and has been renamed twice. Using `@latest` ensures each deploy gets the newest version without manual Dockerfile updates.

## Backward Compatibility
Verified in [openclaw source](https://github.com/openclaw/openclaw/blob/main/src/config/paths.ts) that legacy paths are supported:
- Legacy state dirs: `.clawdbot`, `.moltbot`, `.moldbot`
- Legacy config files: `clawdbot.json`, `moltbot.json`, `moldbot.json`

Existing R2 backups and configs will continue to work.

## Test plan
- [ ] Deploy and verify gateway starts successfully
- [ ] Verify existing config/pairings are preserved
- [ ] Test telegram/discord/slack channels still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)