### PR TITLE
fix: kill stale gateway process on restart

### DIFF
--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -8,11 +8,15 @@
 
 set -e
 
-# Check if clawdbot gateway is already running - bail early if so
+# Kill any existing clawdbot gateway process to ensure fresh start with current env
 # Note: CLI is still named "clawdbot" until upstream renames it
 if pgrep -f "clawdbot gateway" > /dev/null 2>&1; then
-    echo "Moltbot gateway is already running, exiting."
-    exit 0
+    echo "Killing existing clawdbot gateway process..."
+    pkill -f "clawdbot gateway" || true
+    sleep 2
+    # Force kill if still running
+    pkill -9 -f "clawdbot gateway" 2>/dev/null || true
+    sleep 1
 fi
 
 # Paths (clawdbot paths are used internally - upstream hasn't renamed yet)


### PR DESCRIPTION
## Summary

- When `start-moltbot.sh` is invoked after a gateway restart (e.g., via the admin UI "Restart Gateway" button), the old `clawdbot gateway` process may still be running with outdated environment variables (such as a changed gateway token)
- Previously, the script detected the running process via `pgrep` and exited immediately (`exit 0`), leaving the stale process in place with old secrets
- Now the script kills any existing gateway process before starting a new one, ensuring the gateway always starts with the current environment

## Context

This was discovered when changing `MOLTBOT_GATEWAY_TOKEN` via `wrangler secret put` — the admin UI's "Restart Gateway" would kill the `start-moltbot.sh` wrapper but the underlying `clawdbot gateway` child process (with the old token) kept running. Every subsequent `start-moltbot.sh` invocation would find it via `pgrep` and bail out, making it impossible to apply new secrets without destroying the entire container.

## Test plan

- [ ] Set a gateway token, deploy, verify it works
- [ ] Change the token via `wrangler secret put MOLTBOT_GATEWAY_TOKEN`
- [ ] Click "Restart Gateway" in `/_admin/`
- [ ] Verify the new token works without needing a full container rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)