### PR TITLE
Telegram Fixes

### DIFF
--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -188,6 +188,9 @@ if (process.env.TELEGRAM_BOT_TOKEN) {
     config.channels.telegram.botToken = process.env.TELEGRAM_BOT_TOKEN;
     config.channels.telegram.enabled = true;
     config.channels.telegram.dmPolicy = process.env.TELEGRAM_DM_POLICY || 'pairing';
+    if (process.env.TELEGRAM_DM_ALLOW_FROM) {
+        config.channels.telegram.allowFrom = process.env.TELEGRAM_DM_ALLOW_FROM.split(',');
+    }
 }
 
 // Discord configuration


### PR DESCRIPTION
Addresses:
https://github.com/cloudflare/moltworker/issues/58
https://github.com/cloudflare/moltworker/issues/90
https://github.com/cloudflare/moltworker/issues/80
https://github.com/cloudflare/moltworker/issues/57
https://github.com/cloudflare/moltworker/issues/47
https://github.com/cloudflare/moltworker/issues/73
https://github.com/cloudflare/moltworker/issues/82
https://github.com/cloudflare/moltworker/issues/93

Also adds new env var `TELEGRAM_DM_ALLOW_FROM` to approve listed account IDs for interaction via Telegram (using  [`channels.telegram.allowFrom`](https://docs.openclaw.ai/channels/telegram#dm-access) config parameter). This is needed because Telegram approves can't be done at the present time due to lack of access to CLI.

`TELEGRAM_DM_ALLOW_FROM` accepts a comma-separated string of Telegram account IDs. Find out your account ID here: https://docs.openclaw.ai/channels/telegram#finding-your-telegram-user-id

---

I feel like I understand this project fairly well, let me know if you guys would love further help. This project must grow fast and I could be a great asset for your team.