### PR TITLE
feat: add BRAVE_API_KEY support for web search

### DIFF
--- a/src/gateway/env.ts
+++ b/src/gateway/env.ts
@@ -55,6 +55,7 @@ export function buildEnvVars(env: MoltbotEnv): Record<string, string> {
   if (env.SLACK_APP_TOKEN) envVars.SLACK_APP_TOKEN = env.SLACK_APP_TOKEN;
   if (env.CDP_SECRET) envVars.CDP_SECRET = env.CDP_SECRET;
   if (env.WORKER_URL) envVars.WORKER_URL = env.WORKER_URL;
+  if (env.BRAVE_API_KEY) envVars.BRAVE_API_KEY = env.BRAVE_API_KEY;
 
   return envVars;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface MoltbotEnv {
   BROWSER?: Fetcher;
   CDP_SECRET?: string; // Shared secret for CDP endpoint authentication
   WORKER_URL?: string; // Public URL of the worker (for CDP endpoint)
+  BRAVE_API_KEY?: string; // Brave Search API key for web search
 }
 
 /**


### PR DESCRIPTION
Enables Brave Search API integration for OpenClaw's web search capability. Users can configure via: npx wrangler secret put BRAVE_API_KEY