### PR TITLE
test: add e2e test matrix for telegram and discord channel configurations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,23 @@ jobs:
       contents: write
       pull-requests: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: base
+            env: {}
+          - name: telegram
+            env:
+              TELEGRAM_BOT_TOKEN: "fake-telegram-bot-token-for-e2e"
+              TELEGRAM_DM_POLICY: "pairing"
+          - name: discord
+            env:
+              DISCORD_BOT_TOKEN: "fake-discord-bot-token-for-e2e"
+              DISCORD_DM_POLICY: "pairing"
+
+    name: e2e (${{ matrix.config.name }})
+
     steps:
       - uses: actions/checkout@v4
 
@@ -59,12 +76,16 @@ jobs:
         with:
           tool: cctr
 
-      - name: Run E2E tests
+      - name: Run E2E tests (${{ matrix.config.name }})
         id: e2e
         continue-on-error: true
         env:
           AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
           AI_GATEWAY_BASE_URL: ${{ secrets.AI_GATEWAY_BASE_URL }}
+          TELEGRAM_BOT_TOKEN: ${{ matrix.config.env.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_DM_POLICY: ${{ matrix.config.env.TELEGRAM_DM_POLICY }}
+          DISCORD_BOT_TOKEN: ${{ matrix.config.env.DISCORD_BOT_TOKEN }}
+          DISCORD_DM_POLICY: ${{ matrix.config.env.DISCORD_DM_POLICY }}
         run: cctr -vv test/e2e
 
       - name: Convert video and generate thumbnail
@@ -109,11 +130,11 @@ jobs:
         id: prepare
         if: always() && steps.convert.outputs.has_video == 'true'
         run: |
-          mkdir -p /tmp/e2e-video-upload/videos/${{ github.run_id }}
-          cp "${{ steps.convert.outputs.video_path }}" /tmp/e2e-video-upload/videos/${{ github.run_id }}/
-          cp "${{ steps.convert.outputs.thumb_path }}" /tmp/e2e-video-upload/videos/${{ github.run_id }}/
-          echo "video_url=https://github.com/${{ github.repository }}/raw/e2e-artifacts/videos/${{ github.run_id }}/${{ steps.convert.outputs.video_name }}" >> $GITHUB_OUTPUT
-          echo "thumb_url=https://github.com/${{ github.repository }}/raw/e2e-artifacts/videos/${{ github.run_id }}/${{ steps.convert.outputs.thumb_name }}" >> $GITHUB_OUTPUT
+          mkdir -p /tmp/e2e-video-upload/videos/${{ github.run_id }}-${{ matrix.config.name }}
+          cp "${{ steps.convert.outputs.video_path }}" /tmp/e2e-video-upload/videos/${{ github.run_id }}-${{ matrix.config.name }}/
+          cp "${{ steps.convert.outputs.thumb_path }}" /tmp/e2e-video-upload/videos/${{ github.run_id }}-${{ matrix.config.name }}/
+          echo "video_url=https://github.com/${{ github.repository }}/raw/e2e-artifacts/videos/${{ github.run_id }}-${{ matrix.config.name }}/${{ steps.convert.outputs.video_name }}" >> $GITHUB_OUTPUT
+          echo "thumb_url=https://github.com/${{ github.repository }}/raw/e2e-artifacts/videos/${{ github.run_id }}-${{ matrix.config.name }}/${{ steps.convert.outputs.thumb_name }}" >> $GITHUB_OUTPUT
 
       - name: Upload video to e2e-artifacts branch
         if: always() && steps.convert.outputs.has_video == 'true'
@@ -130,7 +151,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ## E2E Test Recording
+            ## E2E Test Recording (${{ matrix.config.name }})
 
             ${{ steps.e2e.outcome == 'success' && '✅ Tests passed' || '❌ Tests failed' }}
 

--- a/test/e2e/fixture/start-server
+++ b/test/e2e/fixture/start-server
@@ -79,8 +79,11 @@ if [ -f "$PROJECT_DIR/.dev.vars" ]; then
     grep -v -E "^(E2E_TEST_MODE|DEV_MODE|DEBUG_ROUTES|MOLTBOT_GATEWAY_TOKEN)=" "$PROJECT_DIR/.dev.vars" >> "$CCTR_FIXTURE_DIR/.dev.vars.e2e" 2>/dev/null || true
 fi
 
-# Also pick up API keys from environment (for CI)
-for var in AI_GATEWAY_API_KEY AI_GATEWAY_BASE_URL ANTHROPIC_API_KEY OPENAI_API_KEY; do
+# Also pick up API keys and channel tokens from environment (for CI)
+for var in AI_GATEWAY_API_KEY AI_GATEWAY_BASE_URL ANTHROPIC_API_KEY OPENAI_API_KEY \
+           TELEGRAM_BOT_TOKEN TELEGRAM_DM_POLICY TELEGRAM_DM_ALLOW_FROM \
+           DISCORD_BOT_TOKEN DISCORD_DM_POLICY \
+           SLACK_BOT_TOKEN SLACK_APP_TOKEN; do
     if [ -n "${!var}" ]; then
         echo "$var=${!var}" >> "$CCTR_FIXTURE_DIR/.dev.vars.e2e"
     fi
@@ -125,11 +128,22 @@ fi
 
 # Wait for server to be ready (container startup can take 1-2 minutes)
 log "Waiting for server to be ready..."
-for i in {1..180}; do
+consecutive_503=0
+TIMEOUT_SECONDS=180
+START_TIME=$(date +%s)
+while true; do
+    ELAPSED=$(($(date +%s) - START_TIME))
+    if [ "$ELAPSED" -ge "$TIMEOUT_SECONDS" ]; then
+        log "Timeout waiting for server after ${ELAPSED}s"
+        [ -n "$TAIL_PID" ] && kill $TAIL_PID 2>/dev/null || true
+        cat "$CCTR_FIXTURE_DIR/wrangler.log" >&2
+        exit 1
+    fi
+
     # Check for 200 response, not just any response
     status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT/?token=$GATEWAY_TOKEN" 2>/dev/null || echo "000")
     if [ "$status" = "200" ]; then
-        log "Server is ready! (HTTP $status)"
+        log "Server is ready! (HTTP $status after ${ELAPSED}s)"
         log "Open: http://localhost:$PORT/?token=$GATEWAY_TOKEN"
         # Kill the tail process if running
         [ -n "$TAIL_PID" ] && kill $TAIL_PID 2>/dev/null || true
@@ -138,14 +152,26 @@ for i in {1..180}; do
         echo "ready"
         exit 0
     fi
-    if [ "$VERBOSE" = true ] && [ $((i % 10)) -eq 0 ]; then
-        log "Still waiting... ($i seconds, last status: $status)"
+    
+    # Track consecutive 503 errors - these indicate the gateway is failing repeatedly
+    if [ "$status" = "503" ]; then
+        consecutive_503=$((consecutive_503 + 1))
+        # After 3 consecutive 503s, check for fatal errors in the log
+        if [ "$consecutive_503" -ge 3 ]; then
+            if grep -q "Config invalid" "$CCTR_FIXTURE_DIR/wrangler.log" 2>/dev/null; then
+                log "Fatal error: Gateway config is invalid"
+                [ -n "$TAIL_PID" ] && kill $TAIL_PID 2>/dev/null || true
+                echo "ERROR: Gateway failed to start due to invalid config:" >&2
+                grep -A5 "Config invalid" "$CCTR_FIXTURE_DIR/wrangler.log" | head -20 >&2
+                exit 1
+            fi
+        fi
+    else
+        consecutive_503=0
+    fi
+    
+    if [ "$VERBOSE" = true ] && [ $((ELAPSED % 10)) -lt 2 ]; then
+        log "Still waiting... (${ELAPSED}s elapsed, last status: $status)"
     fi
     sleep 1
 done
-
-log "Timeout waiting for server"
-# Kill the tail process if running
-[ -n "$TAIL_PID" ] && kill $TAIL_PID 2>/dev/null || true
-cat "$CCTR_FIXTURE_DIR/wrangler.log" >&2
-exit 1


### PR DESCRIPTION
- Pass TELEGRAM_BOT_TOKEN, TELEGRAM_DM_POLICY, TELEGRAM_DM_ALLOW_FROM to e2e test server
- Pass DISCORD_BOT_TOKEN, DISCORD_DM_POLICY to e2e test server
- Pass SLACK_BOT_TOKEN, SLACK_APP_TOKEN to e2e test server
- Add GitHub Actions test matrix with three configurations:
  1. base: AI Gateway only
  2. telegram: AI Gateway + Telegram bot token
  3. discord: AI Gateway + Discord bot token
- Use matrix config name in video artifact paths to avoid conflicts

This test is expected to fail, and #99 should fix it.