### PR TITLE
fix: remove invalid dm config keys for Telegram and Discord

### DIFF
--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -187,17 +187,28 @@ if (process.env.TELEGRAM_BOT_TOKEN) {
     config.channels.telegram = config.channels.telegram || {};
     config.channels.telegram.botToken = process.env.TELEGRAM_BOT_TOKEN;
     config.channels.telegram.enabled = true;
-    config.channels.telegram.dm = config.channels.telegram.dm || {};
-    config.channels.telegram.dmPolicy = process.env.TELEGRAM_DM_POLICY || 'pairing';
+    const telegramDmPolicy = process.env.TELEGRAM_DM_POLICY || 'pairing';
+    config.channels.telegram.dmPolicy = telegramDmPolicy;
+    // "open" policy requires allowFrom: ["*"]
+    if (telegramDmPolicy === 'open') {
+        config.channels.telegram.allowFrom = ['*'];
+    }
 }
 
 // Discord configuration
+// Note: Discord uses nested dm.policy, not flat dmPolicy like Telegram
+// See: https://github.com/moltbot/moltbot/blob/v2026.1.24-1/src/config/zod-schema.providers-core.ts#L147-L155
 if (process.env.DISCORD_BOT_TOKEN) {
     config.channels.discord = config.channels.discord || {};
     config.channels.discord.token = process.env.DISCORD_BOT_TOKEN;
     config.channels.discord.enabled = true;
+    const discordDmPolicy = process.env.DISCORD_DM_POLICY || 'pairing';
     config.channels.discord.dm = config.channels.discord.dm || {};
-    config.channels.discord.dm.policy = process.env.DISCORD_DM_POLICY || 'pairing';
+    config.channels.discord.dm.policy = discordDmPolicy;
+    // "open" policy requires allowFrom: ["*"]
+    if (discordDmPolicy === 'open') {
+        config.channels.discord.dm.allowFrom = ['*'];
+    }
 }
 
 // Slack configuration


### PR DESCRIPTION
## Summary

**Telegram:**
- Remove invalid `dm: {}` key (causes validation error: "Unrecognized key: dm")
- Keep `dmPolicy` at channel level (correct per schema)
- Add `allowFrom: ["*"]` when dmPolicy is 'open'

**Discord:**
- Keep `dm.policy` nested structure (NOT flat `dmPolicy`)
- Discord uses `dm.policy` inside a `dm` object, unlike Telegram which uses flat `dmPolicy`
- Add `dm.allowFrom: ["*"]` when dm.policy is 'open'

## Schema References (moltbot v2026.1.24-1)

- **Telegram** uses flat `dmPolicy`: [zod-schema.providers-core.ts#L85](https://github.com/moltbot/moltbot/blob/v2026.1.24-1/src/config/zod-schema.providers-core.ts#L85)
- **Discord** uses nested `dm.policy`: [zod-schema.providers-core.ts#L147-L155](https://github.com/moltbot/moltbot/blob/v2026.1.24-1/src/config/zod-schema.providers-core.ts#L147-L155)

---

This is based on #99 by @mpkrueger, with corrections for the Discord config structure.

Closes #57
Closes #82
Supersedes #99
Supersedes #44
Supersedes #120