### PR TITLE
fix: use unique branches per matrix job for e2e video uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,8 +133,8 @@ jobs:
           mkdir -p /tmp/e2e-video-upload/videos/${{ github.run_id }}-${{ matrix.config.name }}
           cp "${{ steps.convert.outputs.video_path }}" /tmp/e2e-video-upload/videos/${{ github.run_id }}-${{ matrix.config.name }}/
           cp "${{ steps.convert.outputs.thumb_path }}" /tmp/e2e-video-upload/videos/${{ github.run_id }}-${{ matrix.config.name }}/
-          echo "video_url=https://github.com/${{ github.repository }}/raw/e2e-artifacts/videos/${{ github.run_id }}-${{ matrix.config.name }}/${{ steps.convert.outputs.video_name }}" >> $GITHUB_OUTPUT
-          echo "thumb_url=https://github.com/${{ github.repository }}/raw/e2e-artifacts/videos/${{ github.run_id }}-${{ matrix.config.name }}/${{ steps.convert.outputs.thumb_name }}" >> $GITHUB_OUTPUT
+          echo "video_url=https://github.com/${{ github.repository }}/raw/e2e-artifacts-${{ matrix.config.name }}/videos/${{ github.run_id }}-${{ matrix.config.name }}/${{ steps.convert.outputs.video_name }}" >> $GITHUB_OUTPUT
+          echo "thumb_url=https://github.com/${{ github.repository }}/raw/e2e-artifacts-${{ matrix.config.name }}/videos/${{ github.run_id }}-${{ matrix.config.name }}/${{ steps.convert.outputs.thumb_name }}" >> $GITHUB_OUTPUT
 
       - name: Upload video to e2e-artifacts branch
         if: always() && steps.convert.outputs.has_video == 'true'
@@ -142,8 +142,29 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: /tmp/e2e-video-upload
-          publish_branch: e2e-artifacts
+          publish_branch: e2e-artifacts-${{ matrix.config.name }}
           keep_files: true
+
+      - name: Delete old video comments
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- e2e-video-${{ matrix.config.name }} -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            for (const comment of comments) {
+              if (comment.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id,
+                });
+              }
+            }
 
       - name: Comment on PR with video
         if: always() && github.event_name == 'pull_request' && steps.prepare.outputs.video_url
@@ -151,6 +172,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
+            <!-- e2e-video-${{ matrix.config.name }} -->
             ## E2E Test Recording (${{ matrix.config.name }})
 
             ${{ steps.e2e.outcome == 'success' && '✅ Tests passed' || '❌ Tests failed' }}


### PR DESCRIPTION
## Problem

The three e2e matrix jobs (base, telegram, discord) run in parallel and all try to push to the same `e2e-artifacts` branch. This causes race conditions where some jobs fail with:

```
! [rejected] e2e-artifacts -> e2e-artifacts (fetch first)
error: failed to push some refs
```

## Solution

1. **Unique branches per config**: Each matrix job now pushes to its own branch:
   - `e2e-artifacts-base`
   - `e2e-artifacts-telegram`
   - `e2e-artifacts-discord`

2. **Clean up old comments**: Before posting a new video comment, delete any existing comments from previous CI runs for the same config. Uses an HTML comment marker (`<!-- e2e-video-{config} -->`) to identify comments to delete.

This ensures all three videos are uploaded successfully and PR comments stay clean across multiple CI runs.