### PR TITLE
feat: add TELEGRAM_DM_ALLOW_FROM env var for allowlist policy

### DIFF
--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -189,8 +189,11 @@ if (process.env.TELEGRAM_BOT_TOKEN) {
     config.channels.telegram.enabled = true;
     const telegramDmPolicy = process.env.TELEGRAM_DM_POLICY || 'pairing';
     config.channels.telegram.dmPolicy = telegramDmPolicy;
-    // "open" policy requires allowFrom: ["*"]
-    if (telegramDmPolicy === 'open') {
+    if (process.env.TELEGRAM_DM_ALLOW_FROM) {
+        // Explicit allowlist: "123,456,789" → ['123', '456', '789']
+        config.channels.telegram.allowFrom = process.env.TELEGRAM_DM_ALLOW_FROM.split(',');
+    } else if (telegramDmPolicy === 'open') {
+        // "open" policy requires allowFrom: ["*"]
         config.channels.telegram.allowFrom = ['*'];
     }
 }


### PR DESCRIPTION
Adds support for explicit Telegram user allowlists via the `TELEGRAM_DM_ALLOW_FROM` environment variable.

## DM Access Control Modes

| Mode | Env Vars | Behavior |
|------|----------|----------|
| **pairing** (default) | `TELEGRAM_DM_POLICY=pairing` | Unknown senders get pairing code; owner must approve |
| **allowlist** | `TELEGRAM_DM_POLICY=allowlist` + `TELEGRAM_DM_ALLOW_FROM=123,456` | Only allow specified user IDs |
| **open** | `TELEGRAM_DM_POLICY=open` | Allow all DMs (auto-sets `allowFrom: ['*']`) |

## Example Usage

```bash
# Allow specific Telegram users (comma-separated user IDs)
npx wrangler secret put TELEGRAM_DM_POLICY    # Enter: allowlist
npx wrangler secret put TELEGRAM_DM_ALLOW_FROM # Enter: 123456789,987654321
```

## Related

- Closes #120 (thanks @sinnrrr for the idea!)
- See [OpenClaw Telegram docs](https://docs.openclaw.ai/channels/telegram) for more on DM policies