### PR TITLE
docs: fix CDP endpoint authentication documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,12 +295,12 @@ npm run deploy
 
 | Endpoint | Description |
 |----------|-------------|
-| `GET /cdp/json/version` | Browser version information |
-| `GET /cdp/json/list` | List available browser targets |
-| `GET /cdp/json/new` | Create a new browser target |
-| `WS /cdp/devtools/browser/{id}` | WebSocket connection for CDP commands |
+| `GET /cdp/json/version?secret=<secret>` | Browser version information |
+| `GET /cdp/json/list?secret=<secret>` | List available browser targets |
+| `GET /cdp/json/new?secret=<secret>` | Create a new browser target |
+| `WS /cdp?secret=<secret>` | WebSocket connection for CDP commands |
 
-All endpoints require the `CDP_SECRET` header for authentication.
+All endpoints require the `CDP_SECRET` as a query parameter (`?secret=<value>`) for authentication.
 
 ## Built-in Skills
 


### PR DESCRIPTION
## Summary

The CDP documentation contains two inaccuracies:

1. **Authentication method**: States endpoints require `CDP_SECRET` header, but the implementation uses a query parameter
2. **WebSocket path**: Lists `WS /cdp/devtools/browser/{id}` but the actual endpoint is `WS /cdp`

## Evidence

**Actual implementation** (`src/routes/cdp.ts:155-157`):
```typescript
const url = new URL(c.req.url);
const providedSecret = url.searchParams.get('secret');  // query param, not header
```

**Code comments confirm** (`src/routes/cdp.ts:11`):
```typescript
* Authentication: Pass secret as query param `?secret=<secret>` on WebSocket connect.
```

**Bundled scripts use query params** (`skills/cloudflare-browser/scripts/cdp-client.js:25`):
```javascript
const wsUrl = `wss://${workerUrl}/cdp?secret=${encodeURIComponent(CDP_SECRET)}`;
```

## Changes

- Updated endpoint table to show query parameter syntax
- Corrected WebSocket path from `/cdp/devtools/browser/{id}` to `/cdp`
- Changed "header" to "query parameter" in authentication note