### PR TITLE
Refactor R2 storage mounting process

### DIFF
--- a/src/gateway/r2.ts
+++ b/src/gateway/r2.ts
@@ -54,7 +54,7 @@ export async function mountR2Storage(sandbox: Sandbox, env: MoltbotEnv): Promise
     await new Promise(resolve => setTimeout(resolve, 1000));
 
     console.log('Initiating R2 mount...');
-    await sandbox.mountBucket(R2_BUCKET_NAME, R2_MOUNT_PATH, {
+    await sandbox.mountBucket(bucketName, R2_MOUNT_PATH, {
       endpoint: `https://${env.CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
       credentials: {
         accessKeyId: env.R2_ACCESS_KEY_ID,


### PR DESCRIPTION
Mounting R2 kept failing if it was already mounted, and resulted in a fresh workspace. Over time, if the new workspace is developed, the sync will override the previous files in R2. These changes allows a clean unmount and remount with timeout to avoid a container disconnect issue.