### PR TITLE
Update README with deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ npx wrangler secret put R2_SECRET_ACCESS_KEY
 
 # Your Cloudflare Account ID
 npx wrangler secret put CF_ACCOUNT_ID
+
+# Deploy
+npm run deploy
 ```
 
 To find your Account ID: Go to the [Cloudflare Dashboard](https://dash.cloudflare.com/), click the three dots menu next to your account name, and select "Copy Account ID".


### PR DESCRIPTION
Add deployment instructions to README for R2 Secret setup to persist R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and CF_ACCOUNT_ID to the worker.