### PR TITLE
fix: inject gateway token into WebSocket requests for CF Access users

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -278,8 +278,18 @@ app.all('*', async (c) => {
       console.log('[WS] URL:', url.pathname + redactedSearch);
     }
 
+    // Inject gateway token into WebSocket request if not already present.
+    // CF Access redirects strip query params, so authenticated users lose ?token=.
+    // Since the user already passed CF Access auth, we inject the token server-side.
+    let wsRequest = request;
+    if (c.env.MOLTBOT_GATEWAY_TOKEN && !url.searchParams.has('token')) {
+      const tokenUrl = new URL(url.toString());
+      tokenUrl.searchParams.set('token', c.env.MOLTBOT_GATEWAY_TOKEN);
+      wsRequest = new Request(tokenUrl.toString(), request);
+    }
+
     // Get WebSocket connection to the container
-    const containerResponse = await sandbox.wsConnect(request, MOLTBOT_PORT);
+    const containerResponse = await sandbox.wsConnect(wsRequest, MOLTBOT_PORT);
     console.log('[WS] wsConnect response status:', containerResponse.status);
 
     // Get the container-side WebSocket


### PR DESCRIPTION
## Summary
- When Cloudflare Access is enabled, the authentication redirect strips query parameters from the URL, causing authenticated users to lose the `?token=` parameter
- The worker now injects `MOLTBOT_GATEWAY_TOKEN` into WebSocket requests server-side when the token parameter is missing
- Since the user has already passed CF Access authentication at this point, this is safe and expected

Fixes #58

## Details

The root cause: CF Access redirects (for login) strip query params from the original URL. So even if a user visits `https://example.com/?token=xxx`, after CF Access authentication they land on `https://example.com/` without the token. The gateway dashboard's JavaScript then opens WebSocket connections without `?token=`, and the container gateway rejects them with `1008: Invalid or missing token`.

The fix injects the gateway token at the Worker level before proxying the WebSocket to the container, only when:
1. `MOLTBOT_GATEWAY_TOKEN` is configured
2. The request doesn't already have a `token` query param

## Test plan
- [x] Deploy with CF Access enabled and `MOLTBOT_GATEWAY_TOKEN` set
- [x] Access the gateway dashboard through CF Access (no `?token=` in URL)
- [x] Verify WebSocket connects successfully without "Invalid or missing token" error
- [x] Verify device pairing flow works after WebSocket connects