### PR TITLE
feat: ⬆️ bump openclaw to 2026.2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN npm install -g pnpm
 
 # Install OpenClaw (formerly clawdbot/moltbot)
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.2.3 \
+RUN npm install -g openclaw@2026.2.6 \
     && openclaw --version
 
 # Create OpenClaw directories
@@ -32,7 +32,7 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-02-06-v29-sync-workspace
+# Build cache bust: 2026-02-07-openclaw-2.6-update
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 RUN chmod +x /usr/local/bin/start-openclaw.sh
 


### PR DESCRIPTION
## Summary

Bumps OpenClaw from `2026.2.3` to `2026.2.6` to pick up the latest bug fixes and improvements.

## Changes

- Updates `openclaw` npm package from `2026.2.3` → `2026.2.6` in Dockerfile
- Updates build cache bust comment to trigger fresh Docker layer

## Testing

- ✅ Deployed and verified version with `openclaw --version`
- ✅ Confirmed R2 backup/restore works correctly across container restart
- ✅ Workspace persistence maintained (config, memory, paired devices intact)

## Notes

This is a minor patch version bump with no breaking changes. The update process was clean with no configuration migrations required.