### PR TITLE
Security: redact query strings + WS payloads from logs

### DIFF
--- a/src/routes/cdp.ts
+++ b/src/routes/cdp.ts
@@ -391,7 +391,8 @@ async function initCDPSession(ws: WebSocket, env: MoltbotEnv): Promise<void> {
       return;
     }
 
-    console.log('[CDP] Request:', request.method, request.params);
+    // Never log params: they can include sensitive data (headers, cookies, form values).
+    console.log('[CDP] Request:', request.method);
 
     try {
       const result = await handleCDPMethod(session, request.method, request.params || {}, ws);


### PR DESCRIPTION
Redacts sensitive data from worker logs:
- Never log URL query strings (often contain ?token=... / ?secret=...)
- Stop logging WebSocket message payloads (may contain auth + user content)
- CDP route: avoid logging request params

Motivation: prevent accidental credential leakage via logs.