### PR TITLE
feat: add gateway status indicator and controls to admin UI

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -101,6 +101,16 @@ export async function approveAllDevices(): Promise<ApproveAllResponse> {
   });
 }
 
+export interface GatewayStatusResponse {
+  status: 'running' | 'starting' | 'stopped';
+  processId?: string;
+  error?: string;
+}
+
+export async function getGatewayStatus(): Promise<GatewayStatusResponse> {
+  return apiRequest<GatewayStatusResponse>('/gateway/status');
+}
+
 export interface RestartGatewayResponse {
   success: boolean;
   message?: string;

--- a/src/client/pages/AdminPage.css
+++ b/src/client/pages/AdminPage.css
@@ -161,6 +161,63 @@
   color: var(--text-muted);
 }
 
+.section-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.gateway-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.25rem 0.625rem;
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.gateway-status-badge .status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.gateway-status-badge.running {
+  background-color: rgba(74, 222, 128, 0.15);
+  color: var(--success-color);
+}
+
+.gateway-status-badge.running .status-dot {
+  background-color: var(--success-color);
+}
+
+.gateway-status-badge.starting {
+  background-color: rgba(251, 191, 36, 0.15);
+  color: var(--warning-color);
+}
+
+.gateway-status-badge.starting .status-dot {
+  background-color: var(--warning-color);
+  animation: pulse-dot 1.5s ease-in-out infinite;
+}
+
+.gateway-status-badge.stopped {
+  background-color: rgba(239, 68, 68, 0.15);
+  color: var(--error-color);
+}
+
+.gateway-status-badge.stopped .status-dot {
+  background-color: var(--error-color);
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
 /* Empty state */
 .empty-state {
   text-align: center;

--- a/src/routes/api.test.ts
+++ b/src/routes/api.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv } from '../types';
+import { createMockEnv, createMockSandbox, suppressConsole } from '../test-utils';
+import type { Process } from '@cloudflare/sandbox';
+
+import { api } from './api';
+
+function createFullMockProcess(overrides: Partial<Process> = {}): Process {
+  return {
+    id: 'test-id',
+    command: 'openclaw gateway',
+    status: 'running',
+    startTime: new Date(),
+    endTime: undefined,
+    exitCode: undefined,
+    waitForPort: vi.fn(),
+    kill: vi.fn(),
+    getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+    ...overrides,
+  } as Process;
+}
+
+/**
+ * Build a test app that sets up sandbox on context and mounts the api routes.
+ */
+function createTestApp(mockSandbox: ReturnType<typeof createMockSandbox>) {
+  const app = new Hono<AppEnv>();
+
+  // Middleware: inject sandbox into context (mirrors src/index.ts)
+  app.use('*', async (c, next) => {
+    c.set('sandbox', mockSandbox.sandbox);
+    await next();
+  });
+
+  // Mount the api routes
+  app.route('/api', api);
+
+  return app;
+}
+
+function makeRequest(app: Hono<AppEnv>, path: string, env: Record<string, unknown> = {}) {
+  const mockEnv = createMockEnv({ DEV_MODE: 'true', ...env });
+  return app.request(path, {}, mockEnv);
+}
+
+describe('GET /api/admin/gateway/status', () => {
+  beforeEach(() => {
+    suppressConsole();
+  });
+
+  it('returns stopped when no gateway process found', async () => {
+    const mockSandbox = createMockSandbox({ processes: [] });
+    const app = createTestApp(mockSandbox);
+
+    const res = await makeRequest(app, '/api/admin/gateway/status');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.status).toBe('stopped');
+    expect(body.processId).toBeUndefined();
+  });
+
+  it('returns running when process exists and port responds', async () => {
+    const gatewayProcess = createFullMockProcess({
+      id: 'gw-123',
+      command: 'openclaw gateway --port 18789',
+      status: 'running',
+    });
+    const mockSandbox = createMockSandbox();
+    mockSandbox.listProcessesMock.mockResolvedValue([gatewayProcess]);
+    mockSandbox.containerFetchMock.mockResolvedValue(new Response('OK', { status: 200 }));
+
+    const app = createTestApp(mockSandbox);
+    const res = await makeRequest(app, '/api/admin/gateway/status');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.status).toBe('running');
+    expect(body.processId).toBe('gw-123');
+  });
+
+  it('returns starting when process exists but port does not respond', async () => {
+    const gatewayProcess = createFullMockProcess({
+      id: 'gw-456',
+      command: '/usr/local/bin/start-openclaw.sh',
+      status: 'starting',
+    });
+    const mockSandbox = createMockSandbox();
+    mockSandbox.listProcessesMock.mockResolvedValue([gatewayProcess]);
+    mockSandbox.containerFetchMock.mockRejectedValue(new Error('Connection refused'));
+
+    const app = createTestApp(mockSandbox);
+    const res = await makeRequest(app, '/api/admin/gateway/status');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.status).toBe('starting');
+    expect(body.processId).toBe('gw-456');
+  });
+
+  it('returns stopped when listProcesses fails gracefully', async () => {
+    const mockSandbox = createMockSandbox();
+    mockSandbox.listProcessesMock.mockRejectedValue(new Error('Sandbox unavailable'));
+    // findExistingMoltbotProcess catches listProcesses errors and returns null
+    const app = createTestApp(mockSandbox);
+    const res = await makeRequest(app, '/api/admin/gateway/status');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.status).toBe('stopped');
+  });
+
+  it('returns running even when containerFetch returns a non-200 status', async () => {
+    const gatewayProcess = createFullMockProcess({
+      id: 'gw-789',
+      command: 'openclaw gateway',
+      status: 'running',
+    });
+    const mockSandbox = createMockSandbox();
+    mockSandbox.listProcessesMock.mockResolvedValue([gatewayProcess]);
+    // Gateway responds with 404 — still means port is up
+    mockSandbox.containerFetchMock.mockResolvedValue(new Response('Not Found', { status: 404 }));
+
+    const app = createTestApp(mockSandbox);
+    const res = await makeRequest(app, '/api/admin/gateway/status');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.status).toBe('running');
+    expect(body.processId).toBe('gw-789');
+  });
+
+  it('ignores CLI command processes and returns stopped', async () => {
+    const cliProcess = createFullMockProcess({
+      id: 'cli-1',
+      command: 'openclaw devices list --json',
+      status: 'running',
+    });
+    const mockSandbox = createMockSandbox();
+    mockSandbox.listProcessesMock.mockResolvedValue([cliProcess]);
+
+    const app = createTestApp(mockSandbox);
+    const res = await makeRequest(app, '/api/admin/gateway/status');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.status).toBe('stopped');
+  });
+});

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -7,6 +7,7 @@ import {
   syncToR2,
   waitForProcess,
 } from '../gateway';
+import { MOLTBOT_PORT } from '../config';
 
 // CLI commands can take 10-15 seconds to complete due to WebSocket connection overhead
 const CLI_TIMEOUT_MS = 20000;
@@ -254,6 +255,36 @@ adminApi.post('/storage/sync', async (c) => {
       },
       status,
     );
+  }
+});
+
+// GET /api/admin/gateway/status - Check gateway process status
+adminApi.get('/gateway/status', async (c) => {
+  const sandbox = c.get('sandbox');
+
+  try {
+    const process = await findExistingMoltbotProcess(sandbox);
+
+    if (!process) {
+      return c.json({ status: 'stopped' as const });
+    }
+
+    // Process exists — check if port is responding
+    try {
+      const url = `http://localhost:${MOLTBOT_PORT}/`;
+      const response = await sandbox.containerFetch(new Request(url), MOLTBOT_PORT);
+      // Any response (even 404) means the port is up
+      if (response) {
+        return c.json({ status: 'running' as const, processId: process.id });
+      }
+    } catch {
+      // Port not responding — process is still starting
+    }
+
+    return c.json({ status: 'starting' as const, processId: process.id });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return c.json({ error: errorMessage }, 500);
   }
 });
 


### PR DESCRIPTION
## Summary

Fixes #213

- New `GET /api/admin/gateway/status` endpoint returns `running`, `starting`, or `stopped` based on process existence and port responsiveness
- Status badge in admin UI: green dot "Running", yellow pulsing dot "Starting", red dot "Stopped"
- Button changes to "Start Gateway" (green) when stopped, "Restart Gateway" (red) when running
- After restart, polls status every 2s until running or 60s timeout (replaces alert dialog)
- "Backup Now" button disabled when gateway is not running (sync requires it)
- Skips confirmation dialog when starting a stopped gateway

## Test plan

- [x] 6 new tests for gateway status endpoint (stopped, running, starting, non-200 response, CLI process filtering, listProcesses failure)
- [x] All existing tests pass (90 total)
- [x] Build succeeds
- [ ] Manual test: verify status badge updates correctly after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)