### PR TITLE
Fix R2 persistence: three interacting bugs + sandbox API workarounds

### DIFF
--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -1,5 +1,5 @@
 export { buildEnvVars } from './env';
 export { mountR2Storage } from './r2';
 export { findExistingMoltbotProcess, ensureMoltbotGateway } from './process';
-export { syncToR2 } from './sync';
+export { fireAndForgetSync, syncToR2 } from './sync';
 export { waitForProcess } from './utils';

--- a/src/gateway/r2.test.ts
+++ b/src/gateway/r2.test.ts
@@ -145,8 +145,8 @@ describe('mountR2Storage', () => {
     it('returns true if mount fails but check shows it is actually mounted', async () => {
       const { sandbox, mountBucketMock, startProcessMock } = createMockSandbox();
       startProcessMock
-        .mockResolvedValueOnce(createMockProcess(''))
-        .mockResolvedValueOnce(createMockProcess('s3fs on /data/moltbot type fuse.s3fs\n'));
+        .mockResolvedValueOnce(createMockProcess('not-mounted\n'))
+        .mockResolvedValueOnce(createMockProcess('mounted\n'));
 
       mountBucketMock.mockRejectedValue(new Error('Transient error'));
 

--- a/src/gateway/r2.ts
+++ b/src/gateway/r2.ts
@@ -1,23 +1,24 @@
 import type { Sandbox } from '@cloudflare/sandbox';
 import type { MoltbotEnv } from '../types';
 import { R2_MOUNT_PATH, getR2BucketName } from '../config';
+import { waitForProcess } from './utils';
 
 /**
- * Check if R2 is already mounted by looking at the mount table
+ * Check if R2 is already mounted by looking at the mount table.
+ * Uses stdout marker pattern because getLogs() often returns empty.
  */
 async function isR2Mounted(sandbox: Sandbox): Promise<boolean> {
   try {
-    const proc = await sandbox.startProcess(`mount | grep "s3fs on ${R2_MOUNT_PATH}"`);
-    // Wait for the command to complete
-    let attempts = 0;
-    while (proc.status === 'running' && attempts < 10) {
-      // eslint-disable-next-line no-await-in-loop -- intentional sequential polling
-      await new Promise((r) => setTimeout(r, 200));
-      attempts++;
-    }
+    const proc = await sandbox.startProcess(
+      `mount | grep -q "s3fs on ${R2_MOUNT_PATH}" && echo mounted || echo not-mounted`,
+    );
+    await waitForProcess(proc, 5000);
     const logs = await proc.getLogs();
-    // If stdout has content, the mount exists
-    const mounted = !!(logs.stdout && logs.stdout.includes('s3fs'));
+    const mounted = !!(
+      logs.stdout &&
+      logs.stdout.includes('mounted') &&
+      !logs.stdout.includes('not-mounted')
+    );
     console.log('isR2Mounted check:', mounted, 'stdout:', logs.stdout?.slice(0, 100));
     return mounted;
   } catch (err) {
@@ -34,7 +35,6 @@ async function isR2Mounted(sandbox: Sandbox): Promise<boolean> {
  * @returns true if mounted successfully, false otherwise
  */
 export async function mountR2Storage(sandbox: Sandbox, env: MoltbotEnv): Promise<boolean> {
-  // Skip if R2 credentials are not configured
   if (!env.R2_ACCESS_KEY_ID || !env.R2_SECRET_ACCESS_KEY || !env.CF_ACCOUNT_ID) {
     console.log(
       'R2 storage not configured (missing R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, or CF_ACCOUNT_ID)',
@@ -42,7 +42,6 @@ export async function mountR2Storage(sandbox: Sandbox, env: MoltbotEnv): Promise
     return false;
   }
 
-  // Check if already mounted first - this avoids errors and is faster
   if (await isR2Mounted(sandbox)) {
     console.log('R2 bucket already mounted at', R2_MOUNT_PATH);
     return true;
@@ -53,7 +52,6 @@ export async function mountR2Storage(sandbox: Sandbox, env: MoltbotEnv): Promise
     console.log('Mounting R2 bucket', bucketName, 'at', R2_MOUNT_PATH);
     await sandbox.mountBucket(bucketName, R2_MOUNT_PATH, {
       endpoint: `https://${env.CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-      // Pass credentials explicitly since we use R2_* naming instead of AWS_*
       credentials: {
         accessKeyId: env.R2_ACCESS_KEY_ID,
         secretAccessKey: env.R2_SECRET_ACCESS_KEY,
@@ -65,13 +63,12 @@ export async function mountR2Storage(sandbox: Sandbox, env: MoltbotEnv): Promise
     const errorMessage = err instanceof Error ? err.message : String(err);
     console.log('R2 mount error:', errorMessage);
 
-    // Check again if it's mounted - the error might be misleading
+    // Check again if it's mounted - the error might be misleading (e.g. "already mounted")
     if (await isR2Mounted(sandbox)) {
       console.log('R2 bucket is mounted despite error');
       return true;
     }
 
-    // Don't fail if mounting fails - moltbot can still run without persistent storage
     console.error('Failed to mount R2 bucket:', err);
     return false;
   }

--- a/src/gateway/sync.test.ts
+++ b/src/gateway/sync.test.ts
@@ -42,9 +42,9 @@ describe('syncToR2', () => {
     it('returns error when source has no config file', async () => {
       const { sandbox, startProcessMock } = createMockSandbox();
       startProcessMock
-        .mockResolvedValueOnce(createMockProcess('s3fs on /data/moltbot type fuse.s3fs\n'))
-        .mockResolvedValueOnce(createMockProcess('', { exitCode: 1 })) // No openclaw.json
-        .mockResolvedValueOnce(createMockProcess('', { exitCode: 1 })); // No clawdbot.json either
+        .mockResolvedValueOnce(createMockProcess('mounted\n'))
+        .mockResolvedValueOnce(createMockProcess('')) // No openclaw.json
+        .mockResolvedValueOnce(createMockProcess('')); // No clawdbot.json either
 
       const env = createMockEnvWithR2();
 
@@ -56,62 +56,76 @@ describe('syncToR2', () => {
   });
 
   describe('sync execution', () => {
-    it('returns success when sync completes', async () => {
+    it('returns success when timestamp file is written', async () => {
       const { sandbox, startProcessMock } = createMockSandbox();
       const timestamp = '2026-01-27T12:00:00+00:00';
 
-      // Calls: mount check, check openclaw.json, rsync, cat timestamp
+      // Calls: mount check, config detect, rsync (all-in-one), cat timestamp
       startProcessMock
-        .mockResolvedValueOnce(createMockProcess('s3fs on /data/moltbot type fuse.s3fs\n'))
-        .mockResolvedValueOnce(createMockProcess('ok'))
-        .mockResolvedValueOnce(createMockProcess(''))
-        .mockResolvedValueOnce(createMockProcess(timestamp));
+        .mockResolvedValueOnce(createMockProcess('mounted\n'))
+        .mockResolvedValueOnce(createMockProcess('exists'))
+        .mockResolvedValueOnce(createMockProcess('')) // rsync chain
+        .mockResolvedValueOnce(createMockProcess(timestamp)); // cat timestamp
 
       const env = createMockEnvWithR2();
-
       const result = await syncToR2(sandbox, env);
 
       expect(result.success).toBe(true);
       expect(result.lastSync).toBe(timestamp);
     });
 
-    it('returns error when rsync fails (no timestamp created)', async () => {
-      const { sandbox, startProcessMock } = createMockSandbox();
-
-      // Calls: mount check, check openclaw.json, rsync (fails), cat timestamp (empty)
-      startProcessMock
-        .mockResolvedValueOnce(createMockProcess('s3fs on /data/moltbot type fuse.s3fs\n'))
-        .mockResolvedValueOnce(createMockProcess('ok'))
-        .mockResolvedValueOnce(createMockProcess('', { exitCode: 1 }))
-        .mockResolvedValueOnce(createMockProcess(''));
-
-      const env = createMockEnvWithR2();
-
-      const result = await syncToR2(sandbox, env);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBe('Sync failed');
-    });
-
-    it('verifies rsync command is called with correct flags', async () => {
+    it('falls back to legacy clawdbot config directory', async () => {
       const { sandbox, startProcessMock } = createMockSandbox();
       const timestamp = '2026-01-27T12:00:00+00:00';
 
       startProcessMock
-        .mockResolvedValueOnce(createMockProcess('s3fs on /data/moltbot type fuse.s3fs\n'))
-        .mockResolvedValueOnce(createMockProcess('ok'))
+        .mockResolvedValueOnce(createMockProcess('mounted\n'))
+        .mockResolvedValueOnce(createMockProcess('')) // No openclaw.json
+        .mockResolvedValueOnce(createMockProcess('exists')) // clawdbot.json found
+        .mockResolvedValueOnce(createMockProcess('')) // rsync chain
+        .mockResolvedValueOnce(createMockProcess(timestamp));
+
+      const env = createMockEnvWithR2();
+      const result = await syncToR2(sandbox, env);
+
+      expect(result.success).toBe(true);
+
+      // rsync chain should reference .clawdbot
+      const rsyncCall = startProcessMock.mock.calls[3][0];
+      expect(rsyncCall).toContain('/root/.clawdbot/');
+    });
+
+    it('returns error when no timestamp after sync', async () => {
+      const { sandbox, startProcessMock } = createMockSandbox();
+
+      startProcessMock
+        .mockResolvedValueOnce(createMockProcess('mounted\n'))
+        .mockResolvedValueOnce(createMockProcess('exists'))
+        .mockResolvedValueOnce(createMockProcess('')) // rsync chain
+        .mockResolvedValue(createMockProcess('')); // all cat polls return empty
+
+      const env = createMockEnvWithR2();
+      const result = await syncToR2(sandbox, env, 10, 3); // fast: 10ms interval, 3 polls
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Sync timed out');
+    });
+
+    it('verifies rsync command excludes .git', async () => {
+      const { sandbox, startProcessMock } = createMockSandbox();
+      const timestamp = '2026-01-27T12:00:00+00:00';
+
+      startProcessMock
+        .mockResolvedValueOnce(createMockProcess('mounted\n'))
+        .mockResolvedValueOnce(createMockProcess('exists'))
         .mockResolvedValueOnce(createMockProcess(''))
         .mockResolvedValueOnce(createMockProcess(timestamp));
 
       const env = createMockEnvWithR2();
-
       await syncToR2(sandbox, env);
 
-      // Third call should be rsync to openclaw/ R2 prefix
       const rsyncCall = startProcessMock.mock.calls[2][0];
-      expect(rsyncCall).toContain('rsync');
-      expect(rsyncCall).toContain('--no-times');
-      expect(rsyncCall).toContain('--delete');
+      expect(rsyncCall).toContain("--exclude='.git'");
       expect(rsyncCall).toContain('/root/.openclaw/');
       expect(rsyncCall).toContain('/data/moltbot/openclaw/');
     });

--- a/src/gateway/sync.ts
+++ b/src/gateway/sync.ts
@@ -11,6 +11,81 @@ export interface SyncResult {
   details?: string;
 }
 
+async function runCommand(
+  sandbox: Sandbox,
+  cmd: string,
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; status: string }> {
+  const proc = await sandbox.startProcess(cmd);
+  await waitForProcess(proc, timeoutMs);
+  const logs = await proc.getLogs();
+  // proc.status is a stale snapshot; get fresh status
+  const status = proc.getStatus ? await proc.getStatus() : proc.status;
+  return {
+    stdout: logs.stdout || '',
+    stderr: logs.stderr || '',
+    status,
+  };
+}
+
+function buildSyncCmd(configDir: string): string {
+  // Exclude .git dirs (workspace/.git/ has 50+ hook files, each slow over s3fs).
+  return [
+    `rsync -r --no-times --delete --exclude='*.lock' --exclude='*.log' --exclude='*.tmp' --exclude='.git' ${configDir}/ ${R2_MOUNT_PATH}/openclaw/`,
+    `([ -d /root/clawd ] && rsync -r --no-times --delete --exclude='skills' --exclude='.git' /root/clawd/ ${R2_MOUNT_PATH}/workspace/ || true)`,
+    `([ -d /root/clawd/skills ] && rsync -r --no-times --delete /root/clawd/skills/ ${R2_MOUNT_PATH}/skills/ || true)`,
+    `date -Iseconds > ${R2_MOUNT_PATH}/.last-sync`,
+  ].join(' && ');
+}
+
+/**
+ * Fire-and-forget sync for use in cron handlers.
+ *
+ * Starts the rsync chain but does NOT poll for completion. The scheduled
+ * handler has a strict time limit — polling competes with slow s3fs
+ * operations and can exceed it, causing an unhandled exception that resets
+ * the Durable Object and kills the container.
+ *
+ * The cron fires every 5 minutes, so if one sync fails, the next catches it.
+ */
+export async function fireAndForgetSync(sandbox: Sandbox, env: MoltbotEnv): Promise<void> {
+  if (!env.R2_ACCESS_KEY_ID || !env.R2_SECRET_ACCESS_KEY || !env.CF_ACCOUNT_ID) {
+    console.log('[cron] R2 not configured, skipping');
+    return;
+  }
+
+  const mounted = await mountR2Storage(sandbox, env);
+  if (!mounted) {
+    console.log('[cron] R2 mount failed, skipping');
+    return;
+  }
+
+  const checkNew = await runCommand(
+    sandbox,
+    'test -f /root/.openclaw/openclaw.json && echo exists',
+    5000,
+  );
+  let configDir = '';
+  if (checkNew.stdout.includes('exists')) {
+    configDir = '/root/.openclaw';
+  } else {
+    const checkLegacy = await runCommand(
+      sandbox,
+      'test -f /root/.clawdbot/clawdbot.json && echo exists',
+      5000,
+    );
+    if (checkLegacy.stdout.includes('exists')) {
+      configDir = '/root/.clawdbot';
+    } else {
+      console.log('[cron] No config file found, skipping');
+      return;
+    }
+  }
+
+  await sandbox.startProcess(buildSyncCmd(configDir));
+  console.log('[cron] Sync command started (fire-and-forget)');
+}
+
 /**
  * Sync OpenClaw config and workspace from container to R2 for persistence.
  *
@@ -20,38 +95,44 @@ export interface SyncResult {
  * 3. Runs rsync to copy config, workspace, and skills to R2
  * 4. Writes a timestamp file for tracking
  *
- * Syncs three directories:
+ * Syncs up to three directories:
  * - Config: /root/.openclaw/ (or /root/.clawdbot/) → R2:/openclaw/
- * - Workspace: /root/clawd/ → R2:/workspace/ (IDENTITY.md, MEMORY.md, memory/, assets/)
- * - Skills: /root/clawd/skills/ → R2:/skills/
- *
- * @param sandbox - The sandbox instance
- * @param env - Worker environment bindings
- * @returns SyncResult with success status and optional error details
+ * - Workspace: /root/clawd/ → R2:/workspace/ (if exists)
+ * - Skills: /root/clawd/skills/ → R2:/skills/ (if exists)
  */
-export async function syncToR2(sandbox: Sandbox, env: MoltbotEnv): Promise<SyncResult> {
-  // Check if R2 is configured
+export async function syncToR2(
+  sandbox: Sandbox,
+  env: MoltbotEnv,
+  pollIntervalMs: number = 2000,
+  maxPolls: number = 90,
+): Promise<SyncResult> {
   if (!env.R2_ACCESS_KEY_ID || !env.R2_SECRET_ACCESS_KEY || !env.CF_ACCOUNT_ID) {
     return { success: false, error: 'R2 storage is not configured' };
   }
 
-  // Mount R2 if not already mounted
   const mounted = await mountR2Storage(sandbox, env);
   if (!mounted) {
     return { success: false, error: 'Failed to mount R2 storage' };
   }
 
   // Determine which config directory exists
-  // Check new path first, fall back to legacy
-  // Use exit code (0 = exists) rather than stdout parsing to avoid log-flush races
-  let configDir = '/root/.openclaw';
+  // Use stdout-based detection: exitCode is unreliable (often undefined in sandbox API)
+  let configDir = '';
   try {
-    const checkNew = await sandbox.startProcess('test -f /root/.openclaw/openclaw.json');
-    await waitForProcess(checkNew, 5000);
-    if (checkNew.exitCode !== 0) {
-      const checkLegacy = await sandbox.startProcess('test -f /root/.clawdbot/clawdbot.json');
-      await waitForProcess(checkLegacy, 5000);
-      if (checkLegacy.exitCode === 0) {
+    const checkNew = await runCommand(
+      sandbox,
+      'test -f /root/.openclaw/openclaw.json && echo exists',
+      5000,
+    );
+    if (checkNew.stdout.includes('exists')) {
+      configDir = '/root/.openclaw';
+    } else {
+      const checkLegacy = await runCommand(
+        sandbox,
+        'test -f /root/.clawdbot/clawdbot.json && echo exists',
+        5000,
+      );
+      if (checkLegacy.stdout.includes('exists')) {
         configDir = '/root/.clawdbot';
       } else {
         return {
@@ -69,30 +150,10 @@ export async function syncToR2(sandbox: Sandbox, env: MoltbotEnv): Promise<SyncR
     };
   }
 
-  // Sync to the new openclaw/ R2 prefix (even if source is legacy .clawdbot)
-  // Also sync workspace directory (excluding skills since they're synced separately)
-  const syncCmd = `rsync -r --no-times --delete --exclude='*.lock' --exclude='*.log' --exclude='*.tmp' ${configDir}/ ${R2_MOUNT_PATH}/openclaw/ && rsync -r --no-times --delete --exclude='skills' /root/clawd/ ${R2_MOUNT_PATH}/workspace/ && rsync -r --no-times --delete /root/clawd/skills/ ${R2_MOUNT_PATH}/skills/ && date -Iseconds > ${R2_MOUNT_PATH}/.last-sync`;
+  const syncCmd = buildSyncCmd(configDir);
 
   try {
-    const proc = await sandbox.startProcess(syncCmd);
-    await waitForProcess(proc, 30000); // 30 second timeout for sync
-
-    // Check for success by reading the timestamp file
-    const timestampProc = await sandbox.startProcess(`cat ${R2_MOUNT_PATH}/.last-sync`);
-    await waitForProcess(timestampProc, 5000);
-    const timestampLogs = await timestampProc.getLogs();
-    const lastSync = timestampLogs.stdout?.trim();
-
-    if (lastSync && lastSync.match(/^\d{4}-\d{2}-\d{2}/)) {
-      return { success: true, lastSync };
-    } else {
-      const logs = await proc.getLogs();
-      return {
-        success: false,
-        error: 'Sync failed',
-        details: logs.stderr || logs.stdout || 'No timestamp file created',
-      };
-    }
+    await sandbox.startProcess(syncCmd);
   } catch (err) {
     return {
       success: false,
@@ -100,4 +161,24 @@ export async function syncToR2(sandbox: Sandbox, env: MoltbotEnv): Promise<SyncR
       details: err instanceof Error ? err.message : 'Unknown error',
     };
   }
+
+  // Poll for the timestamp file to appear (proves the entire && chain completed)
+  for (let i = 0; i < maxPolls; i++) {
+    // eslint-disable-next-line no-await-in-loop -- intentional sequential polling
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+    try {
+      const ts = await runCommand(sandbox, `cat ${R2_MOUNT_PATH}/.last-sync`, 10000); // eslint-disable-line no-await-in-loop -- intentional sequential polling
+      const lastSync = ts.stdout.trim();
+      if (lastSync && lastSync.match(/^\d{4}-\d{2}-\d{2}/)) {
+        return { success: true, lastSync };
+      }
+    } catch {
+      // cat failed, keep polling
+    }
+  }
+  return {
+    success: false,
+    error: 'Sync timed out',
+    details: 'Timestamp file not created within 3 minutes',
+  };
 }

--- a/src/gateway/utils.ts
+++ b/src/gateway/utils.ts
@@ -5,20 +5,23 @@
 /**
  * Wait for a sandbox process to complete
  *
- * @param proc - Process object with status property
+ * @param proc - Process object with status and getStatus() method
  * @param timeoutMs - Maximum time to wait in milliseconds
  * @param pollIntervalMs - How often to check status (default 500ms)
  */
 export async function waitForProcess(
-  proc: { status: string },
+  proc: { status: string; getStatus?: () => Promise<string> },
   timeoutMs: number,
   pollIntervalMs: number = 500,
 ): Promise<void> {
   const maxAttempts = Math.ceil(timeoutMs / pollIntervalMs);
   let attempts = 0;
-  while (proc.status === 'running' && attempts < maxAttempts) {
+  let currentStatus = proc.status;
+  while ((currentStatus === 'running' || currentStatus === 'starting') && attempts < maxAttempts) {
     // eslint-disable-next-line no-await-in-loop -- intentional sequential polling
     await new Promise((r) => setTimeout(r, pollIntervalMs));
+    // proc.status is a snapshot; must call getStatus() to refresh
+    currentStatus = proc.getStatus ? await proc.getStatus() : proc.status; // eslint-disable-line no-await-in-loop -- intentional sequential polling
     attempts++;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import { getSandbox, Sandbox, type SandboxOptions } from '@cloudflare/sandbox';
 import type { AppEnv, MoltbotEnv } from './types';
 import { MOLTBOT_PORT } from './config';
 import { createAccessMiddleware } from './auth';
-import { ensureMoltbotGateway, findExistingMoltbotProcess, syncToR2 } from './gateway';
+import { ensureMoltbotGateway, findExistingMoltbotProcess, fireAndForgetSync } from './gateway';
 import { publicRoutes, api, adminUi, debug, cdp } from './routes';
 import { redactSensitiveParams } from './utils/logging';
 import loadingPageHtml from './assets/loading.html';
@@ -463,13 +463,7 @@ async function scheduled(
   }
 
   console.log('[cron] Starting backup sync to R2...');
-  const result = await syncToR2(sandbox, env);
-
-  if (result.success) {
-    console.log('[cron] Backup sync completed successfully at', result.lastSync);
-  } else {
-    console.error('[cron] Backup sync failed:', result.error, result.details || '');
-  }
+  await fireAndForgetSync(sandbox, env);
 }
 
 export default {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -65,15 +65,11 @@ export function createMockSandbox(
   const listProcessesMock = vi.fn().mockResolvedValue(options.processes || []);
   const containerFetchMock = vi.fn();
 
-  // Default: return empty stdout (not mounted), unless mounted: true
+  // Default: 'not-mounted' (isR2Mounted returns false), unless mounted: true
   const startProcessMock = vi
     .fn()
     .mockResolvedValue(
-      options.mounted
-        ? createMockProcess(
-            's3fs on /data/moltbot type fuse.s3fs (rw,nosuid,nodev,relatime,user_id=0,group_id=0)\n',
-          )
-        : createMockProcess(''),
+      options.mounted ? createMockProcess('mounted\n') : createMockProcess('not-mounted\n'),
     );
 
   const sandbox = {

--- a/test/e2e/r2_persistence.txt
+++ b/test/e2e/r2_persistence.txt
@@ -1,0 +1,193 @@
+===
+r2 storage status shows configured
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s "$WORKER_URL/api/admin/storage" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.configured == true
+
+===
+start wrangler tail in background
+%require
+===
+# Source credentials for wrangler
+if [ -f "$CCTR_TEST_PATH/.dev.vars" ]; then
+    set -a
+    source "$CCTR_TEST_PATH/.dev.vars"
+    set +a
+fi
+export CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID"
+WORKER_NAME=$(cat "$CCTR_FIXTURE_DIR/worker-name.txt")
+npx wrangler tail "$WORKER_NAME" --format pretty > "$CCTR_FIXTURE_DIR/wrangler-tail.log" 2>&1 &
+echo $! > "$CCTR_FIXTURE_DIR/wrangler-tail-pid.txt"
+sleep 5
+echo "tail started"
+---
+{{ output }}
+---
+where
+* output contains "tail started"
+
+===
+manual sync succeeds
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+# Retry on transient "Durable Object reset" errors that occur in CI.
+# Suppress retry output — cctr captures both stdout and stderr.
+LAST_RESULT=""
+for attempt in 1 2 3; do
+    LAST_RESULT=$(./curl-auth -s -X POST "$WORKER_URL/api/admin/storage/sync")
+    SUCCESS=$(echo "$LAST_RESULT" | jq -r '.success // false')
+    if [ "$SUCCESS" = "true" ]; then
+        break
+    fi
+    sleep 10
+done
+echo "$LAST_RESULT" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.success == true
+* result.lastSync matches /^\d{4}-\d{2}-\d{2}/
+
+===
+dump wrangler tail logs
+===
+TAIL_PID=$(cat "$CCTR_FIXTURE_DIR/wrangler-tail-pid.txt" 2>/dev/null || echo "")
+if [ -n "$TAIL_PID" ]; then
+    kill "$TAIL_PID" 2>/dev/null || true
+    sleep 1
+fi
+echo "=== WRANGLER TAIL OUTPUT ==="
+sed -E 's/token=[^& "]+/token=REDACTED/g; s/secret=[^& "]+/secret=REDACTED/g' "$CCTR_FIXTURE_DIR/wrangler-tail.log" 2>/dev/null || echo "(empty)"
+echo "=== END ==="
+---
+{{ output }}
+---
+where
+* output contains "WRANGLER TAIL OUTPUT"
+
+===
+second sync also succeeds (idempotent)
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s -X POST "$WORKER_URL/api/admin/storage/sync" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.success == true
+* result.lastSync matches /^\d{4}-\d{2}-\d{2}/
+
+===
+storage status shows last sync timestamp
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s "$WORKER_URL/api/admin/storage" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.configured == true
+* result.lastSync matches /^\d{4}-\d{2}-\d{2}/
+
+===
+create workspace marker file
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s "$WORKER_URL/debug/cli?cmd=echo+e2e-persistence-test+%3E+/root/clawd/e2e-marker.txt+%26%26+echo+done" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.stdout contains "done"
+
+===
+verify marker file exists
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s "$WORKER_URL/debug/cli?cmd=cat+/root/clawd/e2e-marker.txt" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.stdout contains "e2e-persistence-test"
+
+===
+sync after workspace change
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s -X POST "$WORKER_URL/api/admin/storage/sync" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.success == true
+
+===
+restart gateway
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s -X POST "$WORKER_URL/api/admin/gateway/restart" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.success == true
+
+===
+wait for gateway to come back after restart
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+for i in $(seq 1 60); do
+    RESPONSE=$(./curl-auth -s "$WORKER_URL/api/admin/storage" 2>/dev/null || echo "")
+    CONFIGURED=$(echo "$RESPONSE" | jq -r '.configured // empty' 2>/dev/null)
+    if [ "$CONFIGURED" = "true" ]; then
+        echo "gateway ready after ${i} attempts"
+        exit 0
+    fi
+    sleep 5
+done
+echo "gateway did not come back after 60 attempts"
+exit 1
+---
+{{ output }}
+---
+where
+* output contains "gateway ready"
+
+===
+verify marker file survived restart
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s "$WORKER_URL/debug/cli?cmd=cat+/root/clawd/e2e-marker.txt" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.stdout contains "e2e-persistence-test"
+
+===
+sync still works after restart
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s -X POST "$WORKER_URL/api/admin/storage/sync" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.success == true
+* result.lastSync matches /^\d{4}-\d{2}-\d{2}/


### PR DESCRIPTION
Fix three bugs that together prevented R2 backup/restore from working:

Bug 1 - waitForProcess didn't handle 'starting' status:
  The poll loop only waited while status was 'running', exiting
  immediately if a fast command was still 'starting'.

Bug 2 - exitCode null check broke config detection:
  exitCode is often undefined in the sandbox API. Switched to
  stdout-based detection (echo exists) instead of exitCode checks.

Bug 3 - should_restore_from_r2() race condition:
  Called three times (config, workspace, skills) but the config
  restore copied .last-sync locally, making timestamps match and
  skipping workspace/skills. Now evaluates once with DO_RESTORE flag.

Additional fixes discovered during debugging:

- proc.status is a readonly snapshot that never updates. Use getStatus() to poll for actual status changes.

- getStatus() itself returns 'running' indefinitely for shell commands (known sandbox API behavior). Sync now starts the rsync chain and polls for the timestamp file instead of waiting on process status.

- isR2Mounted used getLogs().stdout which was empty (process hadn't completed). Now uses stdout marker pattern with waitForProcess.

- Exclude .git from rsync (workspace/.git/ has 50+ hook files, each taking seconds over s3fs).

- Make workspace/skills rsync non-fatal (directories may not exist in fresh containers).

- Replace inline wait loops in debug.ts with shared waitForProcess.

- Add comprehensive e2e tests covering sync, restart persistence, and workspace marker file survival.

Fixes #212, #228, #102, #86