### PR TITLE
Replace s3fs/rsync with rclone for R2 persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/cloudflare/sandbox:0.7.0
 
-# Install Node.js 22 (required by OpenClaw) and rsync (for R2 backup sync)
+# Install Node.js 22 (required by OpenClaw) and rclone (for R2 persistence)
 # The base image has Node 20, we need to replace it with Node 22
 # Using direct binary download for reliability
 ENV NODE_VERSION=22.13.1
@@ -10,7 +10,7 @@ RUN ARCH="$(dpkg --print-architecture)" \
          arm64) NODE_ARCH="arm64" ;; \
          *) echo "Unsupported architecture: ${ARCH}" >&2; exit 1 ;; \
        esac \
-    && apt-get update && apt-get install -y xz-utils ca-certificates rsync \
+    && apt-get update && apt-get install -y xz-utils ca-certificates rclone \
     && curl -fsSLk https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz -o /tmp/node.tar.xz \
     && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
     && rm /tmp/node.tar.xz \
@@ -32,7 +32,7 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-02-06-v29-sync-workspace
+# Build cache bust: 2026-02-11-v30-rclone
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 RUN chmod +x /usr/local/bin/start-openclaw.sh
 

--- a/src/client/pages/AdminPage.tsx
+++ b/src/client/pages/AdminPage.tsx
@@ -358,8 +358,8 @@ export default function AdminPage() {
               </div>
             ) : (
               <div className="devices-grid">
-                {paired.map((device, index) => (
-                  <div key={device.deviceId || index} className="device-card paired">
+                {paired.map((device) => (
+                  <div key={device.deviceId} className="device-card paired">
                     <div className="device-header">
                       <span className="device-name">
                         {device.displayName || device.deviceId || 'Unknown Device'}

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,9 +8,6 @@ export const MOLTBOT_PORT = 18789;
 /** Maximum time to wait for Moltbot to start (3 minutes) */
 export const STARTUP_TIMEOUT_MS = 180_000;
 
-/** Mount path for R2 persistent storage inside the container */
-export const R2_MOUNT_PATH = '/data/moltbot';
-
 /**
  * R2 bucket name for persistent storage.
  * Can be overridden via R2_BUCKET_NAME env var for test isolation.

--- a/src/gateway/env.ts
+++ b/src/gateway/env.ts
@@ -50,5 +50,10 @@ export function buildEnvVars(env: MoltbotEnv): Record<string, string> {
   if (env.CDP_SECRET) envVars.CDP_SECRET = env.CDP_SECRET;
   if (env.WORKER_URL) envVars.WORKER_URL = env.WORKER_URL;
 
+  // R2 persistence credentials (used by rclone in start-openclaw.sh)
+  if (env.R2_ACCESS_KEY_ID) envVars.R2_ACCESS_KEY_ID = env.R2_ACCESS_KEY_ID;
+  if (env.R2_SECRET_ACCESS_KEY) envVars.R2_SECRET_ACCESS_KEY = env.R2_SECRET_ACCESS_KEY;
+  if (env.R2_BUCKET_NAME) envVars.R2_BUCKET_NAME = env.R2_BUCKET_NAME;
+
   return envVars;
 }

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -1,5 +1,4 @@
-export { buildEnvVars } from './env';
-export { mountR2Storage } from './r2';
-export { findExistingMoltbotProcess, ensureMoltbotGateway } from './process';
-export { fireAndForgetSync, syncToR2 } from './sync';
+export { ensureMoltbotGateway, findExistingMoltbotProcess } from './process';
 export { waitForProcess } from './utils';
+export { ensureRcloneConfig } from './r2';
+export { syncToR2 } from './sync';

--- a/src/gateway/process.ts
+++ b/src/gateway/process.ts
@@ -2,7 +2,7 @@ import type { Sandbox, Process } from '@cloudflare/sandbox';
 import type { MoltbotEnv } from '../types';
 import { MOLTBOT_PORT, STARTUP_TIMEOUT_MS } from '../config';
 import { buildEnvVars } from './env';
-import { mountR2Storage } from './r2';
+import { ensureRcloneConfig } from './r2';
 
 /**
  * Find an existing OpenClaw gateway process
@@ -54,9 +54,9 @@ export async function findExistingMoltbotProcess(sandbox: Sandbox): Promise<Proc
  * @returns The running gateway process
  */
 export async function ensureMoltbotGateway(sandbox: Sandbox, env: MoltbotEnv): Promise<Process> {
-  // Mount R2 storage for persistent data (non-blocking if not configured)
-  // R2 is used as a backup - the startup script will restore from it on boot
-  await mountR2Storage(sandbox, env);
+  // Configure rclone for R2 persistence (non-blocking if not configured).
+  // The startup script uses rclone to restore data from R2 on boot.
+  await ensureRcloneConfig(sandbox, env);
 
   // Check if gateway is already running or starting
   const existingProcess = await findExistingMoltbotProcess(sandbox);

--- a/src/gateway/r2.test.ts
+++ b/src/gateway/r2.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mountR2Storage } from './r2';
+import { ensureRcloneConfig } from './r2';
 import {
   createMockEnv,
   createMockEnvWithR2,
-  createMockProcess,
+  createMockExecResult,
   createMockSandbox,
   suppressConsole,
 } from '../test-utils';
 
-describe('mountR2Storage', () => {
+describe('ensureRcloneConfig', () => {
   beforeEach(() => {
     suppressConsole();
   });
@@ -16,146 +16,58 @@ describe('mountR2Storage', () => {
   describe('credential validation', () => {
     it('returns false when R2_ACCESS_KEY_ID is missing', async () => {
       const { sandbox } = createMockSandbox();
-      const env = createMockEnv({
-        R2_SECRET_ACCESS_KEY: 'secret',
-        CF_ACCOUNT_ID: 'account123',
-      });
-
-      const result = await mountR2Storage(sandbox, env);
-
-      expect(result).toBe(false);
+      const env = createMockEnv({ R2_SECRET_ACCESS_KEY: 'secret', CF_ACCOUNT_ID: 'acct' });
+      expect(await ensureRcloneConfig(sandbox, env)).toBe(false);
     });
 
     it('returns false when R2_SECRET_ACCESS_KEY is missing', async () => {
       const { sandbox } = createMockSandbox();
-      const env = createMockEnv({
-        R2_ACCESS_KEY_ID: 'key123',
-        CF_ACCOUNT_ID: 'account123',
-      });
-
-      const result = await mountR2Storage(sandbox, env);
-
-      expect(result).toBe(false);
+      const env = createMockEnv({ R2_ACCESS_KEY_ID: 'key', CF_ACCOUNT_ID: 'acct' });
+      expect(await ensureRcloneConfig(sandbox, env)).toBe(false);
     });
 
     it('returns false when CF_ACCOUNT_ID is missing', async () => {
       const { sandbox } = createMockSandbox();
-      const env = createMockEnv({
-        R2_ACCESS_KEY_ID: 'key123',
-        R2_SECRET_ACCESS_KEY: 'secret',
-      });
-
-      const result = await mountR2Storage(sandbox, env);
-
-      expect(result).toBe(false);
+      const env = createMockEnv({ R2_ACCESS_KEY_ID: 'key', R2_SECRET_ACCESS_KEY: 'secret' });
+      expect(await ensureRcloneConfig(sandbox, env)).toBe(false);
     });
 
     it('returns false when all R2 credentials are missing', async () => {
       const { sandbox } = createMockSandbox();
       const env = createMockEnv();
-
-      const result = await mountR2Storage(sandbox, env);
-
-      expect(result).toBe(false);
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('R2 storage not configured'),
-      );
+      expect(await ensureRcloneConfig(sandbox, env)).toBe(false);
     });
   });
 
-  describe('mounting behavior', () => {
-    it('mounts R2 bucket when credentials provided and not already mounted', async () => {
-      const { sandbox, mountBucketMock } = createMockSandbox({ mounted: false });
+  describe('configuration behavior', () => {
+    it('skips setup if already configured (flag file exists)', async () => {
+      const { sandbox, execMock, writeFileMock } = createMockSandbox();
+      execMock.mockResolvedValue(createMockExecResult('yes'));
+      const env = createMockEnvWithR2();
+
+      expect(await ensureRcloneConfig(sandbox, env)).toBe(true);
+      expect(writeFileMock).not.toHaveBeenCalled();
+    });
+
+    it('writes rclone config and sets flag when not configured', async () => {
+      const { sandbox, execMock, writeFileMock } = createMockSandbox();
+      execMock
+        .mockResolvedValueOnce(createMockExecResult('no')) // flag check
+        .mockResolvedValueOnce(createMockExecResult()) // mkdir
+        .mockResolvedValueOnce(createMockExecResult()); // touch flag
+
       const env = createMockEnvWithR2({
-        R2_ACCESS_KEY_ID: 'key123',
-        R2_SECRET_ACCESS_KEY: 'secret',
-        CF_ACCOUNT_ID: 'account123',
+        R2_ACCESS_KEY_ID: 'mykey',
+        R2_SECRET_ACCESS_KEY: 'mysecret',
+        CF_ACCOUNT_ID: 'myaccount',
       });
 
-      const result = await mountR2Storage(sandbox, env);
+      expect(await ensureRcloneConfig(sandbox, env)).toBe(true);
 
-      expect(result).toBe(true);
-      expect(mountBucketMock).toHaveBeenCalledWith('moltbot-data', '/data/moltbot', {
-        endpoint: 'https://account123.r2.cloudflarestorage.com',
-        credentials: {
-          accessKeyId: 'key123',
-          secretAccessKey: 'secret',
-        },
-      });
-    });
-
-    it('uses custom bucket name from R2_BUCKET_NAME env var', async () => {
-      const { sandbox, mountBucketMock } = createMockSandbox({ mounted: false });
-      const env = createMockEnvWithR2({
-        R2_ACCESS_KEY_ID: 'key123',
-        R2_SECRET_ACCESS_KEY: 'secret',
-        CF_ACCOUNT_ID: 'account123',
-        R2_BUCKET_NAME: 'moltbot-e2e-test123',
-      });
-
-      const result = await mountR2Storage(sandbox, env);
-
-      expect(result).toBe(true);
-      expect(mountBucketMock).toHaveBeenCalledWith(
-        'moltbot-e2e-test123',
-        '/data/moltbot',
-        expect.any(Object),
-      );
-    });
-
-    it('returns true immediately when bucket is already mounted', async () => {
-      const { sandbox, mountBucketMock } = createMockSandbox({ mounted: true });
-      const env = createMockEnvWithR2();
-
-      const result = await mountR2Storage(sandbox, env);
-
-      expect(result).toBe(true);
-      expect(mountBucketMock).not.toHaveBeenCalled();
-      expect(console.log).toHaveBeenCalledWith('R2 bucket already mounted at', '/data/moltbot');
-    });
-
-    it('logs success message when mounted successfully', async () => {
-      const { sandbox } = createMockSandbox({ mounted: false });
-      const env = createMockEnvWithR2();
-
-      await mountR2Storage(sandbox, env);
-
-      expect(console.log).toHaveBeenCalledWith(
-        'R2 bucket mounted successfully - moltbot data will persist across sessions',
-      );
-    });
-  });
-
-  describe('error handling', () => {
-    it('returns false when mountBucket throws and mount check fails', async () => {
-      const { sandbox, mountBucketMock, startProcessMock } = createMockSandbox({ mounted: false });
-      mountBucketMock.mockRejectedValue(new Error('Mount failed'));
-      startProcessMock
-        .mockResolvedValueOnce(createMockProcess(''))
-        .mockResolvedValueOnce(createMockProcess(''));
-
-      const env = createMockEnvWithR2();
-
-      const result = await mountR2Storage(sandbox, env);
-
-      expect(result).toBe(false);
-      expect(console.error).toHaveBeenCalledWith('Failed to mount R2 bucket:', expect.any(Error));
-    });
-
-    it('returns true if mount fails but check shows it is actually mounted', async () => {
-      const { sandbox, mountBucketMock, startProcessMock } = createMockSandbox();
-      startProcessMock
-        .mockResolvedValueOnce(createMockProcess('not-mounted\n'))
-        .mockResolvedValueOnce(createMockProcess('mounted\n'));
-
-      mountBucketMock.mockRejectedValue(new Error('Transient error'));
-
-      const env = createMockEnvWithR2();
-
-      const result = await mountR2Storage(sandbox, env);
-
-      expect(result).toBe(true);
-      expect(console.log).toHaveBeenCalledWith('R2 bucket is mounted despite error');
+      const writtenConfig = writeFileMock.mock.calls[0][1];
+      expect(writtenConfig).toContain('access_key_id = mykey');
+      expect(writtenConfig).toContain('secret_access_key = mysecret');
+      expect(writtenConfig).toContain('endpoint = https://myaccount.r2.cloudflarestorage.com');
     });
   });
 });

--- a/src/gateway/r2.ts
+++ b/src/gateway/r2.ts
@@ -1,40 +1,17 @@
 import type { Sandbox } from '@cloudflare/sandbox';
 import type { MoltbotEnv } from '../types';
-import { R2_MOUNT_PATH, getR2BucketName } from '../config';
-import { waitForProcess } from './utils';
+import { getR2BucketName } from '../config';
+
+const RCLONE_CONF_PATH = '/root/.config/rclone/rclone.conf';
+const CONFIGURED_FLAG = '/tmp/.rclone-configured';
 
 /**
- * Check if R2 is already mounted by looking at the mount table.
- * Uses stdout marker pattern because getLogs() often returns empty.
- */
-async function isR2Mounted(sandbox: Sandbox): Promise<boolean> {
-  try {
-    const proc = await sandbox.startProcess(
-      `mount | grep -q "s3fs on ${R2_MOUNT_PATH}" && echo mounted || echo not-mounted`,
-    );
-    await waitForProcess(proc, 5000);
-    const logs = await proc.getLogs();
-    const mounted = !!(
-      logs.stdout &&
-      logs.stdout.includes('mounted') &&
-      !logs.stdout.includes('not-mounted')
-    );
-    console.log('isR2Mounted check:', mounted, 'stdout:', logs.stdout?.slice(0, 100));
-    return mounted;
-  } catch (err) {
-    console.log('isR2Mounted error:', err);
-    return false;
-  }
-}
-
-/**
- * Mount R2 bucket for persistent storage
+ * Ensure rclone is configured in the container for R2 access.
+ * Idempotent — checks for a flag file to skip re-configuration.
  *
- * @param sandbox - The sandbox instance
- * @param env - Worker environment bindings
- * @returns true if mounted successfully, false otherwise
+ * @returns true if rclone is configured, false if credentials are missing
  */
-export async function mountR2Storage(sandbox: Sandbox, env: MoltbotEnv): Promise<boolean> {
+export async function ensureRcloneConfig(sandbox: Sandbox, env: MoltbotEnv): Promise<boolean> {
   if (!env.R2_ACCESS_KEY_ID || !env.R2_SECRET_ACCESS_KEY || !env.CF_ACCOUNT_ID) {
     console.log(
       'R2 storage not configured (missing R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, or CF_ACCOUNT_ID)',
@@ -42,34 +19,26 @@ export async function mountR2Storage(sandbox: Sandbox, env: MoltbotEnv): Promise
     return false;
   }
 
-  if (await isR2Mounted(sandbox)) {
-    console.log('R2 bucket already mounted at', R2_MOUNT_PATH);
+  const check = await sandbox.exec(`test -f ${CONFIGURED_FLAG} && echo yes || echo no`);
+  if (check.stdout?.trim() === 'yes') {
     return true;
   }
 
-  const bucketName = getR2BucketName(env);
-  try {
-    console.log('Mounting R2 bucket', bucketName, 'at', R2_MOUNT_PATH);
-    await sandbox.mountBucket(bucketName, R2_MOUNT_PATH, {
-      endpoint: `https://${env.CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-      credentials: {
-        accessKeyId: env.R2_ACCESS_KEY_ID,
-        secretAccessKey: env.R2_SECRET_ACCESS_KEY,
-      },
-    });
-    console.log('R2 bucket mounted successfully - moltbot data will persist across sessions');
-    return true;
-  } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
-    console.log('R2 mount error:', errorMessage);
+  const rcloneConfig = [
+    '[r2]',
+    'type = s3',
+    'provider = Cloudflare',
+    `access_key_id = ${env.R2_ACCESS_KEY_ID}`,
+    `secret_access_key = ${env.R2_SECRET_ACCESS_KEY}`,
+    `endpoint = https://${env.CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    'acl = private',
+    'no_check_bucket = true',
+  ].join('\n');
 
-    // Check again if it's mounted - the error might be misleading (e.g. "already mounted")
-    if (await isR2Mounted(sandbox)) {
-      console.log('R2 bucket is mounted despite error');
-      return true;
-    }
+  await sandbox.exec(`mkdir -p $(dirname ${RCLONE_CONF_PATH})`);
+  await sandbox.writeFile(RCLONE_CONF_PATH, rcloneConfig);
+  await sandbox.exec(`touch ${CONFIGURED_FLAG}`);
 
-    console.error('Failed to mount R2 bucket:', err);
-    return false;
-  }
+  console.log('Rclone configured for R2 bucket:', getR2BucketName(env));
+  return true;
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -2,12 +2,9 @@
  * Shared test utilities for mocking sandbox and environment
  */
 import { vi } from 'vitest';
-import type { Sandbox, Process } from '@cloudflare/sandbox';
+import type { Sandbox, Process, ExecResult } from '@cloudflare/sandbox';
 import type { MoltbotEnv } from './types';
 
-/**
- * Create a minimal MoltbotEnv object for testing
- */
 export function createMockEnv(overrides: Partial<MoltbotEnv> = {}): MoltbotEnv {
   return {
     Sandbox: {} as any,
@@ -17,9 +14,6 @@ export function createMockEnv(overrides: Partial<MoltbotEnv> = {}): MoltbotEnv {
   };
 }
 
-/**
- * Create a mock env with R2 credentials configured
- */
 export function createMockEnvWithR2(overrides: Partial<MoltbotEnv> = {}): MoltbotEnv {
   return createMockEnv({
     R2_ACCESS_KEY_ID: 'test-key-id',
@@ -29,9 +23,6 @@ export function createMockEnvWithR2(overrides: Partial<MoltbotEnv> = {}): Moltbo
   });
 }
 
-/**
- * Create a mock process object
- */
 export function createMockProcess(
   stdout: string = '',
   options: { exitCode?: number; stderr?: string; status?: string } = {},
@@ -44,48 +35,60 @@ export function createMockProcess(
   };
 }
 
+export function createMockExecResult(
+  stdout: string = '',
+  options: { exitCode?: number; stderr?: string; success?: boolean } = {},
+): ExecResult {
+  return {
+    stdout,
+    stderr: options.stderr ?? '',
+    exitCode: options.exitCode ?? 0,
+    success: options.success ?? (options.exitCode ?? 0) === 0,
+    command: '',
+    duration: 0,
+    timestamp: new Date().toISOString(),
+  };
+}
+
 export interface MockSandbox {
   sandbox: Sandbox;
-  mountBucketMock: ReturnType<typeof vi.fn>;
   startProcessMock: ReturnType<typeof vi.fn>;
   listProcessesMock: ReturnType<typeof vi.fn>;
   containerFetchMock: ReturnType<typeof vi.fn>;
+  execMock: ReturnType<typeof vi.fn>;
+  writeFileMock: ReturnType<typeof vi.fn>;
 }
 
-/**
- * Create a mock sandbox with configurable behavior
- */
 export function createMockSandbox(
   options: {
-    mounted?: boolean;
     processes?: Partial<Process>[];
   } = {},
 ): MockSandbox {
-  const mountBucketMock = vi.fn().mockResolvedValue(undefined);
   const listProcessesMock = vi.fn().mockResolvedValue(options.processes || []);
   const containerFetchMock = vi.fn();
-
-  // Default: 'not-mounted' (isR2Mounted returns false), unless mounted: true
-  const startProcessMock = vi
-    .fn()
-    .mockResolvedValue(
-      options.mounted ? createMockProcess('mounted\n') : createMockProcess('not-mounted\n'),
-    );
+  const startProcessMock = vi.fn().mockResolvedValue(createMockProcess());
+  const execMock = vi.fn().mockResolvedValue(createMockExecResult());
+  const writeFileMock = vi.fn().mockResolvedValue(undefined);
 
   const sandbox = {
-    mountBucket: mountBucketMock,
     listProcesses: listProcessesMock,
     startProcess: startProcessMock,
     containerFetch: containerFetchMock,
+    exec: execMock,
+    writeFile: writeFileMock,
     wsConnect: vi.fn(),
   } as unknown as Sandbox;
 
-  return { sandbox, mountBucketMock, startProcessMock, listProcessesMock, containerFetchMock };
+  return {
+    sandbox,
+    startProcessMock,
+    listProcessesMock,
+    containerFetchMock,
+    execMock,
+    writeFileMock,
+  };
 }
 
-/**
- * Suppress console output during tests
- */
 export function suppressConsole() {
   vi.spyOn(console, 'log').mockImplementation(() => {});
   vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/start-openclaw.sh
+++ b/start-openclaw.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Startup script for OpenClaw in Cloudflare Sandbox
 # This script:
-# 1. Restores config from R2 backup if available
+# 1. Restores config/workspace/skills from R2 via rclone (if configured)
 # 2. Runs openclaw onboard --non-interactive to configure from env vars
 # 3. Patches config for features onboard doesn't cover (channels, gateway auth)
-# 4. Starts the gateway
+# 4. Starts a background sync loop (rclone, watches for file changes)
+# 5. Starts the gateway
 
 set -e
 
@@ -15,104 +16,86 @@ fi
 
 CONFIG_DIR="/root/.openclaw"
 CONFIG_FILE="$CONFIG_DIR/openclaw.json"
-BACKUP_DIR="/data/moltbot"
+WORKSPACE_DIR="/root/clawd"
+SKILLS_DIR="/root/clawd/skills"
+RCLONE_CONF="/root/.config/rclone/rclone.conf"
+LAST_SYNC_FILE="/tmp/.last-sync"
 
 echo "Config directory: $CONFIG_DIR"
-echo "Backup directory: $BACKUP_DIR"
 
 mkdir -p "$CONFIG_DIR"
 
 # ============================================================
-# RESTORE FROM R2 BACKUP
+# RCLONE SETUP
 # ============================================================
 
-should_restore_from_r2() {
-    local R2_SYNC_FILE="$BACKUP_DIR/.last-sync"
-    local LOCAL_SYNC_FILE="$CONFIG_DIR/.last-sync"
-
-    if [ ! -f "$R2_SYNC_FILE" ]; then
-        echo "No R2 sync timestamp found, skipping restore"
-        return 1
-    fi
-
-    if [ ! -f "$LOCAL_SYNC_FILE" ]; then
-        echo "No local sync timestamp, will restore from R2"
-        return 0
-    fi
-
-    R2_TIME=$(cat "$R2_SYNC_FILE" 2>/dev/null)
-    LOCAL_TIME=$(cat "$LOCAL_SYNC_FILE" 2>/dev/null)
-
-    echo "R2 last sync: $R2_TIME"
-    echo "Local last sync: $LOCAL_TIME"
-
-    R2_EPOCH=$(date -d "$R2_TIME" +%s 2>/dev/null || echo "0")
-    LOCAL_EPOCH=$(date -d "$LOCAL_TIME" +%s 2>/dev/null || echo "0")
-
-    if [ "$R2_EPOCH" -gt "$LOCAL_EPOCH" ]; then
-        echo "R2 backup is newer, will restore"
-        return 0
-    else
-        echo "Local data is newer or same, skipping restore"
-        return 1
-    fi
+r2_configured() {
+    [ -n "$R2_ACCESS_KEY_ID" ] && [ -n "$R2_SECRET_ACCESS_KEY" ] && [ -n "$CF_ACCOUNT_ID" ]
 }
 
-# Evaluate restore decision once, before any restore operations.
-# This avoids a race where the config restore copies .last-sync into $CONFIG_DIR,
-# making subsequent should_restore_from_r2 calls return false (timestamps match).
-DO_RESTORE=false
-if should_restore_from_r2; then
-    DO_RESTORE=true
-fi
+R2_BUCKET="${R2_BUCKET_NAME:-moltbot-data}"
 
-# Check for backup data in new openclaw/ prefix first, then legacy clawdbot/ prefix
-if [ "$DO_RESTORE" = true ] && [ -f "$BACKUP_DIR/openclaw/openclaw.json" ]; then
-    echo "Restoring from R2 backup at $BACKUP_DIR/openclaw..."
-    cp -a "$BACKUP_DIR/openclaw/." "$CONFIG_DIR/"
-    cp -f "$BACKUP_DIR/.last-sync" "$CONFIG_DIR/.last-sync" 2>/dev/null || true
-    echo "Restored config from R2 backup"
-elif [ "$DO_RESTORE" = true ] && [ -f "$BACKUP_DIR/clawdbot/clawdbot.json" ]; then
-    # Legacy backup format — migrate .clawdbot data into .openclaw
-    echo "Restoring from legacy R2 backup at $BACKUP_DIR/clawdbot..."
-    cp -a "$BACKUP_DIR/clawdbot/." "$CONFIG_DIR/"
-    cp -f "$BACKUP_DIR/.last-sync" "$CONFIG_DIR/.last-sync" 2>/dev/null || true
-    if [ -f "$CONFIG_DIR/clawdbot.json" ] && [ ! -f "$CONFIG_FILE" ]; then
-        mv "$CONFIG_DIR/clawdbot.json" "$CONFIG_FILE"
+setup_rclone() {
+    mkdir -p "$(dirname "$RCLONE_CONF")"
+    cat > "$RCLONE_CONF" << EOF
+[r2]
+type = s3
+provider = Cloudflare
+access_key_id = $R2_ACCESS_KEY_ID
+secret_access_key = $R2_SECRET_ACCESS_KEY
+endpoint = https://${CF_ACCOUNT_ID}.r2.cloudflarestorage.com
+acl = private
+no_check_bucket = true
+EOF
+    touch /tmp/.rclone-configured
+    echo "Rclone configured for bucket: $R2_BUCKET"
+}
+
+RCLONE_FLAGS="--transfers=16 --fast-list --s3-no-check-bucket"
+
+# ============================================================
+# RESTORE FROM R2
+# ============================================================
+
+if r2_configured; then
+    setup_rclone
+
+    echo "Checking R2 for existing backup..."
+    # Check if R2 has an openclaw config backup
+    if rclone ls "r2:${R2_BUCKET}/openclaw/openclaw.json" $RCLONE_FLAGS 2>/dev/null | grep -q openclaw.json; then
+        echo "Restoring config from R2..."
+        rclone copy "r2:${R2_BUCKET}/openclaw/" "$CONFIG_DIR/" $RCLONE_FLAGS -v 2>&1 || echo "WARNING: config restore failed with exit code $?"
+        echo "Config restored"
+    elif rclone ls "r2:${R2_BUCKET}/clawdbot/clawdbot.json" $RCLONE_FLAGS 2>/dev/null | grep -q clawdbot.json; then
+        echo "Restoring from legacy R2 backup..."
+        rclone copy "r2:${R2_BUCKET}/clawdbot/" "$CONFIG_DIR/" $RCLONE_FLAGS -v 2>&1 || echo "WARNING: legacy config restore failed with exit code $?"
+        if [ -f "$CONFIG_DIR/clawdbot.json" ] && [ ! -f "$CONFIG_FILE" ]; then
+            mv "$CONFIG_DIR/clawdbot.json" "$CONFIG_FILE"
+        fi
+        echo "Legacy config restored and migrated"
+    else
+        echo "No backup found in R2, starting fresh"
     fi
-    echo "Restored and migrated config from legacy R2 backup"
-elif [ "$DO_RESTORE" = true ] && [ -f "$BACKUP_DIR/clawdbot.json" ]; then
-    # Very old legacy backup format (flat structure)
-    echo "Restoring from flat legacy R2 backup at $BACKUP_DIR..."
-    cp -a "$BACKUP_DIR/." "$CONFIG_DIR/"
-    cp -f "$BACKUP_DIR/.last-sync" "$CONFIG_DIR/.last-sync" 2>/dev/null || true
-    if [ -f "$CONFIG_DIR/clawdbot.json" ] && [ ! -f "$CONFIG_FILE" ]; then
-        mv "$CONFIG_DIR/clawdbot.json" "$CONFIG_FILE"
+
+    # Restore workspace
+    REMOTE_WS_COUNT=$(rclone ls "r2:${R2_BUCKET}/workspace/" $RCLONE_FLAGS 2>/dev/null | wc -l)
+    if [ "$REMOTE_WS_COUNT" -gt 0 ]; then
+        echo "Restoring workspace from R2 ($REMOTE_WS_COUNT files)..."
+        mkdir -p "$WORKSPACE_DIR"
+        rclone copy "r2:${R2_BUCKET}/workspace/" "$WORKSPACE_DIR/" $RCLONE_FLAGS -v 2>&1 || echo "WARNING: workspace restore failed with exit code $?"
+        echo "Workspace restored"
     fi
-    echo "Restored and migrated config from flat legacy R2 backup"
-elif [ -d "$BACKUP_DIR" ]; then
-    echo "R2 mounted at $BACKUP_DIR but no backup data found yet"
+
+    # Restore skills
+    REMOTE_SK_COUNT=$(rclone ls "r2:${R2_BUCKET}/skills/" $RCLONE_FLAGS 2>/dev/null | wc -l)
+    if [ "$REMOTE_SK_COUNT" -gt 0 ]; then
+        echo "Restoring skills from R2 ($REMOTE_SK_COUNT files)..."
+        mkdir -p "$SKILLS_DIR"
+        rclone copy "r2:${R2_BUCKET}/skills/" "$SKILLS_DIR/" $RCLONE_FLAGS -v 2>&1 || echo "WARNING: skills restore failed with exit code $?"
+        echo "Skills restored"
+    fi
 else
-    echo "R2 not mounted, starting fresh"
-fi
-
-# Restore workspace from R2 backup if available
-# This includes IDENTITY.md, USER.md, MEMORY.md, memory/, and assets/
-WORKSPACE_DIR="/root/clawd"
-if [ "$DO_RESTORE" = true ] && [ -d "$BACKUP_DIR/workspace" ] && [ "$(ls -A $BACKUP_DIR/workspace 2>/dev/null)" ]; then
-    echo "Restoring workspace from $BACKUP_DIR/workspace..."
-    mkdir -p "$WORKSPACE_DIR"
-    cp -a "$BACKUP_DIR/workspace/." "$WORKSPACE_DIR/"
-    echo "Restored workspace from R2 backup"
-fi
-
-# Restore skills from R2 backup if available
-SKILLS_DIR="/root/clawd/skills"
-if [ "$DO_RESTORE" = true ] && [ -d "$BACKUP_DIR/skills" ] && [ "$(ls -A $BACKUP_DIR/skills 2>/dev/null)" ]; then
-    echo "Restoring skills from $BACKUP_DIR/skills..."
-    mkdir -p "$SKILLS_DIR"
-    cp -a "$BACKUP_DIR/skills/." "$SKILLS_DIR/"
-    echo "Restored skills from R2 backup"
+    echo "R2 not configured, starting fresh"
 fi
 
 # ============================================================
@@ -280,6 +263,51 @@ if (process.env.SLACK_BOT_TOKEN && process.env.SLACK_APP_TOKEN) {
 fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 console.log('Configuration patched successfully');
 EOFPATCH
+
+# ============================================================
+# BACKGROUND SYNC LOOP
+# ============================================================
+if r2_configured; then
+    echo "Starting background R2 sync loop..."
+    (
+        MARKER=/tmp/.last-sync-marker
+        LOGFILE=/tmp/r2-sync.log
+        touch "$MARKER"
+
+        while true; do
+            sleep 30
+
+            CHANGED=/tmp/.changed-files
+            {
+                find "$CONFIG_DIR" -newer "$MARKER" -type f -printf '%P\n' 2>/dev/null
+                find "$WORKSPACE_DIR" -newer "$MARKER" \
+                    -not -path '*/node_modules/*' \
+                    -not -path '*/.git/*' \
+                    -type f -printf '%P\n' 2>/dev/null
+            } > "$CHANGED"
+
+            COUNT=$(wc -l < "$CHANGED" 2>/dev/null || echo 0)
+
+            if [ "$COUNT" -gt 0 ]; then
+                echo "[sync] Uploading changes ($COUNT files) at $(date)" >> "$LOGFILE"
+                rclone sync "$CONFIG_DIR/" "r2:${R2_BUCKET}/openclaw/" \
+                    $RCLONE_FLAGS --exclude='*.lock' --exclude='*.log' --exclude='*.tmp' --exclude='.git/**' 2>> "$LOGFILE"
+                if [ -d "$WORKSPACE_DIR" ]; then
+                    rclone sync "$WORKSPACE_DIR/" "r2:${R2_BUCKET}/workspace/" \
+                        $RCLONE_FLAGS --exclude='skills/**' --exclude='.git/**' --exclude='node_modules/**' 2>> "$LOGFILE"
+                fi
+                if [ -d "$SKILLS_DIR" ]; then
+                    rclone sync "$SKILLS_DIR/" "r2:${R2_BUCKET}/skills/" \
+                        $RCLONE_FLAGS 2>> "$LOGFILE"
+                fi
+                date -Iseconds > "$LAST_SYNC_FILE"
+                touch "$MARKER"
+                echo "[sync] Complete at $(date)" >> "$LOGFILE"
+            fi
+        done
+    ) &
+    echo "Background sync loop started (PID: $!)"
+fi
 
 # ============================================================
 # START GATEWAY

--- a/test/e2e/r2_persistence.txt
+++ b/test/e2e/r2_persistence.txt
@@ -41,7 +41,7 @@ WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
 LAST_RESULT=""
 for attempt in 1 2 3; do
     LAST_RESULT=$(./curl-auth -s -X POST "$WORKER_URL/api/admin/storage/sync")
-    SUCCESS=$(echo "$LAST_RESULT" | jq -r '.success // false')
+    SUCCESS=$(echo "$LAST_RESULT" | jq -r '.success // false' 2>/dev/null)
     if [ "$SUCCESS" = "true" ]; then
         break
     fi
@@ -111,19 +111,7 @@ where
 * result.stdout contains "done"
 
 ===
-verify marker file exists
-%require
-===
-WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
-./curl-auth -s "$WORKER_URL/debug/cli?cmd=cat+/root/clawd/e2e-marker.txt" | jq .
----
-{{ result: json object }}
----
-where
-* result.stdout contains "e2e-persistence-test"
-
-===
-sync after workspace change
+sync workspace with marker file
 %require
 ===
 WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
@@ -135,7 +123,57 @@ where
 * result.success == true
 
 ===
-restart gateway
+verify marker file reached R2
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+BUCKET=$(cat "$CCTR_FIXTURE_DIR/r2-bucket-name.txt" 2>/dev/null || echo "moltbot-data")
+./curl-auth -s "$WORKER_URL/debug/cli?cmd=rclone+ls+r2:${BUCKET}/workspace/e2e-marker.txt" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.stdout contains "e2e-marker.txt"
+
+===
+verify config reached R2
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+BUCKET=$(cat "$CCTR_FIXTURE_DIR/r2-bucket-name.txt" 2>/dev/null || echo "moltbot-data")
+./curl-auth -s "$WORKER_URL/debug/cli?cmd=rclone+ls+r2:${BUCKET}/openclaw/openclaw.json" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.stdout contains "openclaw.json"
+
+===
+stop background sync and delete marker file locally
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s "$WORKER_URL/debug/cli?cmd=pkill+-f+r2-sync.sh;+rm+/root/clawd/e2e-marker.txt+%26%26+echo+deleted" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.stdout contains "deleted"
+
+===
+confirm marker file is gone locally
+%require
+===
+WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
+./curl-auth -s "$WORKER_URL/debug/cli?cmd=test+-f+/root/clawd/e2e-marker.txt+%26%26+echo+exists+||+echo+missing" | jq .
+---
+{{ result: json object }}
+---
+where
+* result.stdout contains "missing"
+
+===
+restart gateway to trigger restore from R2
 %require
 ===
 WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
@@ -147,33 +185,22 @@ where
 * result.success == true
 
 ===
-wait for gateway to come back after restart
+verify marker file restored from R2 after restart
 %require
 ===
 WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
-for i in $(seq 1 60); do
-    RESPONSE=$(./curl-auth -s "$WORKER_URL/api/admin/storage" 2>/dev/null || echo "")
-    CONFIGURED=$(echo "$RESPONSE" | jq -r '.configured // empty' 2>/dev/null)
-    if [ "$CONFIGURED" = "true" ]; then
-        echo "gateway ready after ${i} attempts"
+# Poll for the marker file — start-openclaw.sh runs rclone restore
+# before starting the gateway, but the Worker responds before the
+# gateway process finishes starting.
+for i in $(seq 1 30); do
+    RESPONSE=$(./curl-auth -s "$WORKER_URL/debug/cli?cmd=cat+/root/clawd/e2e-marker.txt" 2>/dev/null || echo "")
+    if echo "$RESPONSE" | jq -r '.stdout // empty' 2>/dev/null | grep -q "e2e-persistence-test"; then
+        echo "$RESPONSE" | jq .
         exit 0
     fi
     sleep 5
 done
-echo "gateway did not come back after 60 attempts"
-exit 1
----
-{{ output }}
----
-where
-* output contains "gateway ready"
-
-===
-verify marker file survived restart
-%require
-===
-WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
-./curl-auth -s "$WORKER_URL/debug/cli?cmd=cat+/root/clawd/e2e-marker.txt" | jq .
+echo "$RESPONSE" | jq .
 ---
 {{ result: json object }}
 ---
@@ -181,7 +208,7 @@ where
 * result.stdout contains "e2e-persistence-test"
 
 ===
-sync still works after restart
+sync still works after restore
 ===
 WORKER_URL=$(cat "$CCTR_FIXTURE_DIR/worker-url.txt")
 ./curl-auth -s -X POST "$WORKER_URL/api/admin/storage/sync" | jq .

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -62,10 +62,7 @@
       "bucket_name": "moltbot-data",
     },
   ],
-  // Cron trigger to sync moltbot data to R2 every 5 minutes
-  "triggers": {
-    "crons": ["*/5 * * * *"],
-  },
+
   // Browser Rendering binding for CDP shim
   "browser": {
     "binding": "BROWSER",


### PR DESCRIPTION
Replace the FUSE mount (s3fs) + rsync approach with rclone for direct S3 API access. This eliminates the root cause of slow syncs (200-400s) and the cascading bugs caused by s3fs latency.

Key changes:

- Dockerfile: install rclone instead of rsync
- Restore: startup script uses rclone copy from R2 (fast, parallel)
- Backup: uses rclone sync (not copy) to propagate deletions to R2
- Background sync loop runs IN the container, watches for file changes every 30s and uploads via rclone sync
- Manual sync: uses sandbox.exec() which returns ExecResult directly, eliminating all startProcess/getStatus/polling workarounds
- Remove cron trigger: no more Worker-side scheduled handler that could exceed time limits and reset the Durable Object
- Remove FUSE mount: no mountBucket, no isR2Mounted, no R2_MOUNT_PATH
- Pass R2 credentials to container env for rclone config
- Rclone restore commands tolerate transient R2 errors (prevent set -e from killing the startup script on flaky API responses)
- E2e tests verify data reaches R2 (rclone ls) and test the full backup-delete-restart-restore cycle via gateway restart