### PR TITLE
feat: add Feishu (Lark) channel support

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -36,6 +36,13 @@ MOLTBOT_GATEWAY_TOKEN=dev-token-change-in-prod
 # Optional chat channels
 # TELEGRAM_BOT_TOKEN=optional
 # DISCORD_BOT_TOKEN=optional
+# Feishu (Lark) - requires @openclaw/feishu in container; FEISHU_DOMAIN=lark for international
+# FEISHU_APP_ID=cli_xxx
+# FEISHU_APP_SECRET=xxx
+# Feishu (Lark) - requires @openclaw/feishu in container; use lark domain for international
+# FEISHU_APP_ID=cli_xxx
+# FEISHU_APP_SECRET=your-app-secret
+# FEISHU_DOMAIN=lark   # only for Lark (international) tenant
 
 # CDP (Chrome DevTools Protocol) configuration for browser automation
 # CDP_SECRET=shared-secret-for-cdp-auth

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,27 @@ RUN npm install -g pnpm
 
 # Install OpenClaw (formerly clawdbot/moltbot)
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.2.3 \
+RUN npm install -g openclaw@2026.2.13 \
     && openclaw --version
 
-# Create OpenClaw directories
+# Create OpenClaw directories first (plugin install needs .openclaw)
 # Legacy .clawdbot paths are kept for R2 backup migration
-RUN mkdir -p /root/.openclaw \
+RUN mkdir -p /root/.openclaw/extensions \
     && mkdir -p /root/clawd \
     && mkdir -p /root/clawd/skills
 
+# Install Feishu (Lark) channel plugin - patch workspace:* to openclaw version then npm install
+RUN cd /tmp \
+    && npm pack @openclaw/feishu \
+    && tar -xzf openclaw-feishu-*.tgz \
+    && mv package /root/.openclaw/extensions/feishu \
+    && cd /root/.openclaw/extensions/feishu \
+    && sed -i 's/"openclaw": "workspace:\*"/"openclaw": "2026.2.13"/' package.json \
+    && npm install --legacy-peer-deps --omit=dev \
+    && rm -f /tmp/openclaw-feishu-*.tgz
+
 # Copy startup script
-# Build cache bust: 2026-02-11-v30-rclone
+# Build cache bust: 2026-02-15-v32-feishu-legacy-peer-deps
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 RUN chmod +x /usr/local/bin/start-openclaw.sh
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,19 @@ npx wrangler secret put SLACK_APP_TOKEN
 npm run deploy
 ```
 
+### Feishu (飞书 / Lark)
+
+The container image includes the `@openclaw/feishu` plugin. Configure your Feishu app at [Feishu Open Platform](https://open.feishu.cn/app) (or [Lark](https://open.larksuite.com/app) for international), enable bot capability and event subscription with **WebSocket long connection** for `im.message.receive_v1`, then set secrets:
+
+```bash
+npx wrangler secret put FEISHU_APP_ID
+npx wrangler secret put FEISHU_APP_SECRET
+# Optional, for Lark (international): npx wrangler secret put FEISHU_DOMAIN  # value: lark
+npm run deploy
+```
+
+After deploy, approve pairing: in Control UI or `openclaw pairing approve feishu <request_id>`. See [OpenClaw Feishu docs](https://docs.openclaw.ai/channels/feishu).
+
 ## Optional: Browser Automation (CDP)
 
 This worker includes a Chrome DevTools Protocol (CDP) shim that enables browser automation capabilities. This allows OpenClaw to control a headless browser for tasks like web scraping, screenshots, and automated testing.
@@ -436,6 +449,9 @@ The previous `AI_GATEWAY_API_KEY` + `AI_GATEWAY_BASE_URL` approach is still supp
 | `DISCORD_DM_POLICY` | No | Discord DM policy: `pairing` (default) or `open` |
 | `SLACK_BOT_TOKEN` | No | Slack bot token |
 | `SLACK_APP_TOKEN` | No | Slack app token |
+| `FEISHU_APP_ID` | No | Feishu (Lark) app ID (`cli_xxx`) |
+| `FEISHU_APP_SECRET` | No | Feishu (Lark) app secret |
+| `FEISHU_DOMAIN` | No | Feishu API domain: `lark` for international Lark |
 | `CDP_SECRET` | No | Shared secret for CDP endpoint authentication (see [Browser Automation](#optional-browser-automation-cdp)) |
 | `WORKER_URL` | No | Public URL of the worker (required for CDP) |
 

--- a/src/gateway/env.test.ts
+++ b/src/gateway/env.test.ts
@@ -110,6 +110,9 @@ describe('buildEnvVars', () => {
       DISCORD_DM_POLICY: 'open',
       SLACK_BOT_TOKEN: 'slack-bot',
       SLACK_APP_TOKEN: 'slack-app',
+      FEISHU_APP_ID: 'cli_xxx',
+      FEISHU_APP_SECRET: 'secret',
+      FEISHU_DOMAIN: 'lark',
     });
     const result = buildEnvVars(env);
 
@@ -119,6 +122,9 @@ describe('buildEnvVars', () => {
     expect(result.DISCORD_DM_POLICY).toBe('open');
     expect(result.SLACK_BOT_TOKEN).toBe('slack-bot');
     expect(result.SLACK_APP_TOKEN).toBe('slack-app');
+    expect(result.FEISHU_APP_ID).toBe('cli_xxx');
+    expect(result.FEISHU_APP_SECRET).toBe('secret');
+    expect(result.FEISHU_DOMAIN).toBe('lark');
   });
 
   it('maps DEV_MODE to OPENCLAW_DEV_MODE for container', () => {

--- a/src/gateway/env.ts
+++ b/src/gateway/env.ts
@@ -45,6 +45,9 @@ export function buildEnvVars(env: MoltbotEnv): Record<string, string> {
   if (env.DISCORD_DM_POLICY) envVars.DISCORD_DM_POLICY = env.DISCORD_DM_POLICY;
   if (env.SLACK_BOT_TOKEN) envVars.SLACK_BOT_TOKEN = env.SLACK_BOT_TOKEN;
   if (env.SLACK_APP_TOKEN) envVars.SLACK_APP_TOKEN = env.SLACK_APP_TOKEN;
+  if (env.FEISHU_APP_ID) envVars.FEISHU_APP_ID = env.FEISHU_APP_ID;
+  if (env.FEISHU_APP_SECRET) envVars.FEISHU_APP_SECRET = env.FEISHU_APP_SECRET;
+  if (env.FEISHU_DOMAIN) envVars.FEISHU_DOMAIN = env.FEISHU_DOMAIN;
   if (env.CF_AI_GATEWAY_MODEL) envVars.CF_AI_GATEWAY_MODEL = env.CF_AI_GATEWAY_MODEL;
   if (env.CF_ACCOUNT_ID) envVars.CF_ACCOUNT_ID = env.CF_ACCOUNT_ID;
   if (env.CDP_SECRET) envVars.CDP_SECRET = env.CDP_SECRET;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@
  * - TELEGRAM_BOT_TOKEN: Telegram bot token
  * - DISCORD_BOT_TOKEN: Discord bot token
  * - SLACK_BOT_TOKEN + SLACK_APP_TOKEN: Slack tokens
+ * - FEISHU_APP_ID + FEISHU_APP_SECRET: Feishu (Lark) bot (requires @openclaw/feishu in container)
  */
 
 import { Hono } from 'hono';

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,10 @@ export interface MoltbotEnv {
   DISCORD_DM_POLICY?: string;
   SLACK_BOT_TOKEN?: string;
   SLACK_APP_TOKEN?: string;
+  // Feishu (Lark) channel - requires @openclaw/feishu plugin in container
+  FEISHU_APP_ID?: string;
+  FEISHU_APP_SECRET?: string;
+  FEISHU_DOMAIN?: string; // 'lark' for international Lark tenant
   // Cloudflare Access configuration for admin routes
   CF_ACCESS_TEAM_DOMAIN?: string; // e.g., 'myteam.cloudflareaccess.com'
   CF_ACCESS_AUD?: string; // Application Audience (AUD) tag

--- a/start-openclaw.sh
+++ b/start-openclaw.sh
@@ -260,6 +260,24 @@ if (process.env.SLACK_BOT_TOKEN && process.env.SLACK_APP_TOKEN) {
     };
 }
 
+// Feishu (Lark) configuration - requires @openclaw/feishu plugin
+// See https://docs.openclaw.ai/channels/feishu
+if (process.env.FEISHU_APP_ID && process.env.FEISHU_APP_SECRET) {
+    config.channels.feishu = {
+        enabled: true,
+        dmPolicy: 'pairing',
+        accounts: {
+            main: {
+                appId: process.env.FEISHU_APP_ID,
+                appSecret: process.env.FEISHU_APP_SECRET,
+            },
+        },
+    };
+    if (process.env.FEISHU_DOMAIN) {
+        config.channels.feishu.domain = process.env.FEISHU_DOMAIN;
+    }
+}
+
 fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 console.log('Configuration patched successfully');
 EOFPATCH


### PR DESCRIPTION
## Summary
- Add support for Feishu (飞书) and Lark messaging platform
- Install `@openclaw/feishu` plugin in Docker container  
- Add `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_DOMAIN` environment variables
- Update README with Feishu setup documentation

## Test plan
- [x] Unit tests pass (82 tests)
- [x] Lint passes
- [x] Format check passes
- [x] Type check passes
- [ ] E2E tests (will run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)