### PR TITLE
fix: call sandbox.start() before using container

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,7 @@ app.use('*', async (c, next) => {
 app.use('*', async (c, next) => {
   const options = buildSandboxOptions(c.env);
   const sandbox = getSandbox(c.env.Sandbox, 'moltbot', options);
+  await sandbox.start();
   c.set('sandbox', sandbox);
   await next();
 });


### PR DESCRIPTION
Fixes #291

## Summary

- `getSandbox()` returns a sandbox instance but does not boot the container
- Any call to `containerFetch()` or `wsConnect()` before `start()` throws: `The container is not running, consider calling start()`
- Added `await sandbox.start()` in the sandbox middleware — it is idempotent so calling it on every request is safe
