### PR TITLE
Update OpenClaw to 2026.2.25 and fix Deploy button URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN npm install -g pnpm
 
 # Install OpenClaw (formerly clawdbot/moltbot)
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.2.3 \
+ARG OPENCLAW_VERSION=2026.2.25
+RUN npm install -g openclaw@${OPENCLAW_VERSION} \
     && openclaw --version
 
 # Create OpenClaw directories

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Run [OpenClaw](https://github.com/openclaw/openclaw) (formerly Moltbot, formerly
 
 > **Experimental:** This is a proof of concept demonstrating that OpenClaw can run in Cloudflare Sandbox. It is not officially supported and may break without notice. Use at your own risk.
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/moltworker)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/kyutarou/moltworker-update)
 
 ## Requirements
 


### PR DESCRIPTION
- Bump OpenClaw from 2026.2.3 to 2026.2.25 (latest stable)
- Add ARG OPENCLAW_VERSION for easier future version updates
- Fix Deploy to Cloudflare button to point to this fork instead of upstream

https://claude.ai/code/session_01KA4BjE68whcKjuvvkb3tAT