### PR TITLE
feat: CF_AIG_TOKEN support for AI Gateway Authenticated Gateway

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -10,6 +10,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 # CF_AI_GATEWAY_ACCOUNT_ID=your-account-id
 # CF_AI_GATEWAY_GATEWAY_ID=your-gateway-id
 # CF_AI_GATEWAY_MODEL=workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast
+# CF_AIG_TOKEN=your-ai-gateway-auth-token
 
 # Legacy AI Gateway (still supported)
 # AI_GATEWAY_API_KEY=your-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,7 @@ These are the env vars passed TO the container (internal names):
 | `CF_AI_GATEWAY_ACCOUNT_ID` | (env var) | Account ID for AI Gateway |
 | `CF_AI_GATEWAY_GATEWAY_ID` | (env var) | Gateway ID for AI Gateway |
 | `OPENCLAW_GATEWAY_TOKEN` | `--token` flag | Mapped from `MOLTBOT_GATEWAY_TOKEN` |
+| `CF_AIG_TOKEN` | `cf-aig-authorization` header via fetch hook | AI Gateway auth token, injected for `gateway.ai.cloudflare.com` requests |
 | `OPENCLAW_DEV_MODE` | `controlUi.allowInsecureAuth` | Mapped from `DEV_MODE` |
 | `TELEGRAM_BOT_TOKEN` | `channels.telegram.botToken` | |
 | `DISCORD_BOT_TOKEN` | `channels.discord.token` | |

--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ The previous `AI_GATEWAY_API_KEY` + `AI_GATEWAY_BASE_URL` approach is still supp
 | `CF_AI_GATEWAY_ACCOUNT_ID` | Yes* | Your Cloudflare account ID (used to construct the gateway URL) |
 | `CF_AI_GATEWAY_GATEWAY_ID` | Yes* | Your AI Gateway ID (used to construct the gateway URL) |
 | `CF_AI_GATEWAY_MODEL` | No | Override default model: `provider/model-id` (e.g. `workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast`). See [Choosing a Model](#choosing-a-model) |
+| `CF_AIG_TOKEN` | No | AI Gateway authentication token. Enables [Authenticated Gateway](https://developers.cloudflare.com/ai-gateway/configuration/authentication/) and BYOK. Create in CF Dashboard > AI > AI Gateway > Settings > Create token |
 | `ANTHROPIC_API_KEY` | Yes* | Direct Anthropic API key (alternative to AI Gateway) |
 | `ANTHROPIC_BASE_URL` | No | Direct Anthropic API base URL |
 | `OPENAI_API_KEY` | No | OpenAI API key (alternative provider) |

--- a/src/gateway/env.test.ts
+++ b/src/gateway/env.test.ts
@@ -144,6 +144,23 @@ describe('buildEnvVars', () => {
     expect(result.CF_ACCOUNT_ID).toBe('acct-123');
   });
 
+  it('passes CF_AIG_TOKEN to container', () => {
+    const env = createMockEnv({ CF_AIG_TOKEN: 'aig-token-abc123' });
+    const result = buildEnvVars(env);
+    expect(result.CF_AIG_TOKEN).toBe('aig-token-abc123');
+  });
+
+  it('does not include CF_AIG_TOKEN when not set', () => {
+    const env = createMockEnv();
+    const result = buildEnvVars(env);
+    expect(result.CF_AIG_TOKEN).toBeUndefined();
+  });
+
+  it('rejects CF_AIG_TOKEN with control characters', () => {
+    const env = createMockEnv({ CF_AIG_TOKEN: 'token\x00injected' });
+    expect(() => buildEnvVars(env)).toThrow('invalid control characters');
+  });
+
   it('combines all env vars correctly', () => {
     const env = createMockEnv({
       ANTHROPIC_API_KEY: 'sk-key',

--- a/src/gateway/env.ts
+++ b/src/gateway/env.ts
@@ -1,6 +1,19 @@
 import type { MoltbotEnv } from '../types';
 
 /**
+ * Validation: Environment variables passed to the container should be
+ * validated for control characters that could cause injection or parsing
+ * issues. Use validateEnvValue() for any new sensitive token additions.
+ */
+function validateEnvValue(value: string): string {
+  // eslint-disable-next-line no-control-regex -- intentionally matching control characters
+  if (/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/.test(value)) {
+    throw new Error('Environment variable contains invalid control characters');
+  }
+  return value;
+}
+
+/**
  * Build environment variables to pass to the OpenClaw container process
  *
  * @param env - Worker environment bindings
@@ -46,6 +59,7 @@ export function buildEnvVars(env: MoltbotEnv): Record<string, string> {
   if (env.SLACK_BOT_TOKEN) envVars.SLACK_BOT_TOKEN = env.SLACK_BOT_TOKEN;
   if (env.SLACK_APP_TOKEN) envVars.SLACK_APP_TOKEN = env.SLACK_APP_TOKEN;
   if (env.CF_AI_GATEWAY_MODEL) envVars.CF_AI_GATEWAY_MODEL = env.CF_AI_GATEWAY_MODEL;
+  if (env.CF_AIG_TOKEN) envVars.CF_AIG_TOKEN = validateEnvValue(env.CF_AIG_TOKEN);
   if (env.CF_ACCOUNT_ID) envVars.CF_ACCOUNT_ID = env.CF_ACCOUNT_ID;
   if (env.CDP_SECRET) envVars.CDP_SECRET = env.CDP_SECRET;
   if (env.WORKER_URL) envVars.WORKER_URL = env.WORKER_URL;

--- a/src/gateway/r2.ts
+++ b/src/gateway/r2.ts
@@ -37,6 +37,7 @@ export async function ensureRcloneConfig(sandbox: Sandbox, env: MoltbotEnv): Pro
 
   await sandbox.exec(`mkdir -p $(dirname ${RCLONE_CONF_PATH})`);
   await sandbox.writeFile(RCLONE_CONF_PATH, rcloneConfig);
+  await sandbox.exec(`chmod 600 ${RCLONE_CONF_PATH}`);
   await sandbox.exec(`touch ${CONFIGURED_FLAG}`);
 
   console.log('Rclone configured for R2 bucket:', getR2BucketName(env));

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface MoltbotEnv {
   CF_AI_GATEWAY_GATEWAY_ID?: string; // AI Gateway ID
   CLOUDFLARE_AI_GATEWAY_API_KEY?: string; // API key for requests through the gateway
   CF_AI_GATEWAY_MODEL?: string; // Override model: "provider/model-id" e.g. "workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast"
+  CF_AIG_TOKEN?: string; // AI Gateway authentication token (cf-aig-authorization header)
   // Legacy AI Gateway configuration (still supported for backward compat)
   AI_GATEWAY_API_KEY?: string; // API key for the provider configured in AI Gateway
   AI_GATEWAY_BASE_URL?: string; // AI Gateway URL (e.g., https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/anthropic)

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -80,6 +80,7 @@
   // - Legacy AI Gateway (still supported):
   //   - AI_GATEWAY_API_KEY: API key
   //   - AI_GATEWAY_BASE_URL: Gateway endpoint URL
+  //   - CF_AIG_TOKEN: AI Gateway authentication token (enables Authenticated Gateway + BYOK)
   //
   // Authentication:
   // - MOLTBOT_GATEWAY_TOKEN: Token to protect gateway access


### PR DESCRIPTION
## Summary

Adds `CF_AIG_TOKEN` support to enable [AI Gateway Authenticated Gateway](https://developers.cloudflare.com/ai-gateway/configuration/authentication/) and BYOK (Bring Your Own Key). This resolves the inability to use Authenticated Gateway or BYOK with moltworker — users currently must either disable Authenticated Gateway or pass raw provider keys into the container.

Fixes #74 | Duplicates: #119 | Related: #192

## Changes

**Feature — CF_AIG_TOKEN passthrough + header injection:**
- Add `CF_AIG_TOKEN` to `MoltbotEnv` type definition
- Pass `CF_AIG_TOKEN` from Worker env to container via `buildEnvVars()`
- Inject `cf-aig-authorization: Bearer <token>` header via Node.js `--require` hook that patches `globalThis.fetch` for `gateway.ai.cloudflare.com` requests

**Why a fetch hook instead of provider config?** OpenClaw's config schema strictly validates provider objects and rejects unrecognized keys like `defaultHeaders`. This was discovered during live testing (see proof of work below). The `--require` hook approach is scoped: it only patches `fetch()` calls targeting AI Gateway URLs and does not affect other HTTP traffic.

**Security hardening (scoped to touched files):**
- `chmod 600` on `rclone.conf` (both shell script and Worker-side `r2.ts`)
- `chmod 600` on `openclaw.json` after config patch (`fs.chmodSync`)
- Remove redundant gateway token from config file (already passed via `--token` CLI flag — writing it to the config is unnecessary secret exposure)
- Input validation on `CF_AIG_TOKEN` for control characters that could cause injection or parsing issues

> **Note:** This PR narrowly scopes security improvements to files touched by the feature. Broader security concerns in the existing codebase have been identified and will be filed as separate issues.

## Proof of Work — Live Testing on Deployed Instance

Validated on a production Cloudflare Sandbox deployment (a moltworker-based system with AI Gateway + OpenRouter):

1. **Initial attempt with `defaultHeaders` in provider config** — OpenClaw rejected the config:
   ```
   Invalid config at /root/.openclaw/openclaw.json:
   - models.providers.cf-ai-gw-openrouter: Unrecognized key: "defaultHeaders"
   Config invalid
   ```

2. **Replaced with `NODE_OPTIONS --require` fetch hook** — container started successfully:
   ```
   Starting process with command: /usr/local/bin/start-openclaw.sh
   ['CLOUDFLARE_AI_GATEWAY_API_KEY', 'CF_AI_GATEWAY_ACCOUNT_ID', 'CF_AI_GATEWAY_GATEWAY_ID',
    'OPENROUTER_API_KEY', 'ANTHROPIC_API_KEY', 'OPENCLAW_GATEWAY_TOKEN', 'CF_AI_GATEWAY_MODEL',
    'CF_AIG_TOKEN', 'CF_ACCOUNT_ID', 'R2_ACCESS_KEY_ID', 'R2_SECRET_ACCESS_KEY', 'R2_BUCKET_NAME']
   ```

3. **Gateway started and accepted connections** — logs show:
   ```
   Found existing gateway process:
   Gateway is reachable
   [WS] Proxying WebSocket connection to gateway
   ```

4. **Security hardening confirmed** — `chmod 600 /root/.config/rclone/rclone.conf` executed successfully in container logs.

## Test plan

- [x] 85 unit tests pass (82 existing + 3 new CF_AIG_TOKEN tests)
- [x] TypeScript typecheck clean (`tsc --noEmit`)
- [x] Lint clean (`oxlint` — 3 pre-existing errors in `skills/` unrelated to this PR)
- [x] Live deployment test: container starts, gateway reachable, no config validation errors
- [ ] End-to-end: verify `cf-aig-authorization` header appears in AI Gateway request logs (requires AI Gateway dashboard access)

## Files changed

| File | Change |
|------|--------|
| `src/types.ts` | Add `CF_AIG_TOKEN` to `MoltbotEnv` |
| `src/gateway/env.ts` | Add `validateEnvValue()`, `CF_AIG_TOKEN` passthrough with validation |
| `src/gateway/env.test.ts` | 3 new tests: passthrough, not-set, control char rejection |
| `src/gateway/r2.ts` | `chmod 600` on rclone.conf |
| `start-openclaw.sh` | Fetch hook for `cf-aig-authorization`, `chmod 600` on configs, remove redundant token |
| `wrangler.jsonc` | Document `CF_AIG_TOKEN` secret |
| `README.md` | Add to secrets table |
| `.dev.vars.example` | Add commented example |
| `AGENTS.md` | Add to container env var table |

🤖 Generated with [Claude Code](https://claude.ai/code)