### PR TITLE
feat: opt-in auto-update for openclaw on container boot

### DIFF
--- a/src/gateway/env.ts
+++ b/src/gateway/env.ts
@@ -47,6 +47,7 @@ export function buildEnvVars(env: MoltbotEnv): Record<string, string> {
   if (env.SLACK_APP_TOKEN) envVars.SLACK_APP_TOKEN = env.SLACK_APP_TOKEN;
   if (env.CF_AI_GATEWAY_MODEL) envVars.CF_AI_GATEWAY_MODEL = env.CF_AI_GATEWAY_MODEL;
   if (env.CF_ACCOUNT_ID) envVars.CF_ACCOUNT_ID = env.CF_ACCOUNT_ID;
+  if (env.OPENCLAW_AUTO_UPDATE) envVars.OPENCLAW_AUTO_UPDATE = env.OPENCLAW_AUTO_UPDATE;
   if (env.CDP_SECRET) envVars.CDP_SECRET = env.CDP_SECRET;
   if (env.WORKER_URL) envVars.WORKER_URL = env.WORKER_URL;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface MoltbotEnv {
   E2E_TEST_MODE?: string; // Set to 'true' for E2E tests (skips CF Access auth but keeps device pairing)
   DEBUG_ROUTES?: string; // Set to 'true' to enable /debug/* routes
   SANDBOX_SLEEP_AFTER?: string; // How long before sandbox sleeps: 'never' (default), or duration like '10m', '1h'
+  OPENCLAW_AUTO_UPDATE?: string; // Set to 'true' to auto-update openclaw on container boot
   TELEGRAM_BOT_TOKEN?: string;
   TELEGRAM_DM_POLICY?: string;
   DISCORD_BOT_TOKEN?: string;

--- a/start-openclaw.sh
+++ b/start-openclaw.sh
@@ -99,6 +99,28 @@ else
 fi
 
 # ============================================================
+# SELF-UPDATE OPENCLAW (opt-in via OPENCLAW_AUTO_UPDATE=true)
+# ============================================================
+# When enabled, updates openclaw to the latest npm version on every cold start
+# so bug fixes and new features land without a full wrangler deploy.
+# The Dockerfile-pinned version serves as a fallback if npm is unreachable.
+if [ "$OPENCLAW_AUTO_UPDATE" = "true" ]; then
+    CURRENT_VER=$(openclaw --version 2>/dev/null || echo "unknown")
+    echo "Current openclaw version: $CURRENT_VER"
+    echo "Auto-update enabled, checking for updates..."
+    if npm install -g openclaw@latest --prefer-online 2>&1; then
+        NEW_VER=$(openclaw --version 2>/dev/null || echo "unknown")
+        if [ "$CURRENT_VER" != "$NEW_VER" ]; then
+            echo "Updated openclaw: $CURRENT_VER -> $NEW_VER"
+        else
+            echo "openclaw is already at latest ($CURRENT_VER)"
+        fi
+    else
+        echo "WARNING: openclaw update failed, continuing with $CURRENT_VER"
+    fi
+fi
+
+# ============================================================
 # ONBOARD (only if no config exists yet)
 # ============================================================
 if [ ! -f "$CONFIG_FILE" ]; then


### PR DESCRIPTION
## Summary
- Adds opt-in auto-update for openclaw on container cold start
- Gated behind `OPENCLAW_AUTO_UPDATE=true` env var (no behavior change by default)
- On boot, runs `npm install -g openclaw@latest` to pick up bug fixes without a full `wrangler deploy`
- Falls back gracefully to the Dockerfile-pinned version if npm is unreachable

## Changes
- `start-openclaw.sh`: New self-update section before onboarding, gated by `OPENCLAW_AUTO_UPDATE`
- `src/types.ts`: Add `OPENCLAW_AUTO_UPDATE` to `MoltbotEnv`
- `src/gateway/env.ts`: Pass `OPENCLAW_AUTO_UPDATE` through to container

## Usage
```bash
wrangler secret put OPENCLAW_AUTO_UPDATE
# Enter: true
```

## Test plan
- [ ] Without `OPENCLAW_AUTO_UPDATE` set: no change in behavior, skips update
- [ ] With `OPENCLAW_AUTO_UPDATE=true`: logs version check, updates if newer version available
- [ ] With npm unreachable: logs warning, continues with pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)