### PR TITLE
Fix missing sandbox.start() call in middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,7 @@ app.use('*', async (c, next) => {
 app.use('*', async (c, next) => {
   const options = buildSandboxOptions(c.env);
   const sandbox = getSandbox(c.env.Sandbox, 'moltbot', options);
+  await sandbox.start();
   c.set('sandbox', sandbox);
   await next();
 });


### PR DESCRIPTION
Fixes #291.

The sandbox middleware was getting a sandbox instance but never calling sandbox.start() before setting it in the Hono context. This caused containerFetch and wsConnect to fail with 'container is not running' errors on every request.

Fixed by adding await sandbox.start() before setting the sandbox in context. The start() method is idempotent (no-op if already running) so calling it on every request is safe.