### PR TITLE
fix: set default model to openai/gpt-4o when only OPENAI_API_KEY is provided

### DIFF
--- a/start-openclaw.sh
+++ b/start-openclaw.sh
@@ -174,6 +174,18 @@ if (process.env.OPENCLAW_DEV_MODE === 'true') {
 // so we don't need to patch the provider config. Writing a provider
 // entry without a models array breaks OpenClaw's config validation.
 
+// OpenAI-only fallback: when OPENAI_API_KEY is set but no CF_AI_GATEWAY_MODEL
+// and no default model is configured, set gpt-4o as the default so the
+// chatbot produces actual responses instead of failing silently.
+if (process.env.OPENAI_API_KEY && !process.env.CF_AI_GATEWAY_MODEL) {
+    config.agents = config.agents || {};
+    config.agents.defaults = config.agents.defaults || {};
+    if (!config.agents.defaults.model) {
+        config.agents.defaults.model = { primary: 'openai/gpt-4o' };
+        console.log('OpenAI-only mode: set default model to openai/gpt-4o');
+    }
+}
+
 // AI Gateway model override (CF_AI_GATEWAY_MODEL=provider/model-id)
 // Adds a provider entry for any AI Gateway provider and sets it as default model.
 // Examples:


### PR DESCRIPTION
## Summary

- Set `agents.defaults.model` to `openai/gpt-4o` when `OPENAI_API_KEY` is the only provider key configured

## Problem

When a user sets only `OPENAI_API_KEY` (no `ANTHROPIC_API_KEY`, no `CF_AI_GATEWAY_MODEL`), the chatbot returns empty responses with no error. The `openclaw onboard` step correctly saves the OpenAI key, but the config patch in `start-openclaw.sh` never sets `agents.defaults.model`. The gateway then falls back to its built-in default model (which requires a provider key that isn't configured), and fails silently.

## Root Cause

The config patch only sets `agents.defaults.model` inside the `CF_AI_GATEWAY_MODEL` block (line 183+). When that env var is absent, no default model is ever written, regardless of which provider keys are available.

## Fix

Add an OpenAI-only fallback block before the `CF_AI_GATEWAY_MODEL` handler. When `OPENAI_API_KEY` is set and `CF_AI_GATEWAY_MODEL` is not, and no `agents.defaults.model` exists in the config, set it to `{ primary: "openai/gpt-4o" }`.

The guard `!config.agents.defaults.model` ensures we never overwrite a user-configured default, and the `!process.env.CF_AI_GATEWAY_MODEL` guard ensures the existing AI Gateway path still takes full control when present.

## Testing

- With only `OPENAI_API_KEY` set: config now has `agents.defaults.model.primary = "openai/gpt-4o"`
- With both `OPENAI_API_KEY` and `CF_AI_GATEWAY_MODEL` set: AI Gateway block handles it (no change)
- With only `ANTHROPIC_API_KEY` set: no change (onboard configures the default via its own logic)
- With an existing `agents.defaults.model` in R2-restored config: preserved (guard prevents overwrite)

Closes #280