### PR TITLE
docs: rename CF_ACCOUNT_ID to CLOUDFLARE_ACCOUNT_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ npx wrangler secret put R2_ACCESS_KEY_ID
 npx wrangler secret put R2_SECRET_ACCESS_KEY
 
 # Your Cloudflare Account ID
-npx wrangler secret put CF_ACCOUNT_ID
+npx wrangler secret put CLOUDFLARE_ACCOUNT_ID
 ```
 
 To find your Account ID: Go to the [Cloudflare Dashboard](https://dash.cloudflare.com/), click the three dots menu next to your account name, and select "Copy Account ID".
@@ -429,7 +429,7 @@ The previous `AI_GATEWAY_API_KEY` + `AI_GATEWAY_BASE_URL` approach is still supp
 | `SANDBOX_SLEEP_AFTER` | No | Container sleep timeout: `never` (default) or duration like `10m`, `1h` |
 | `R2_ACCESS_KEY_ID` | No | R2 access key for persistent storage |
 | `R2_SECRET_ACCESS_KEY` | No | R2 secret key for persistent storage |
-| `CF_ACCOUNT_ID` | No | Cloudflare account ID (required for R2 storage) |
+| `CLOUDFLARE_ACCOUNT_ID` | No | Cloudflare account ID (required for R2 storage) |
 | `TELEGRAM_BOT_TOKEN` | No | Telegram bot token |
 | `TELEGRAM_DM_POLICY` | No | Telegram DM policy: `pairing` (default) or `open` |
 | `DISCORD_BOT_TOKEN` | No | Discord bot token |
@@ -461,7 +461,7 @@ OpenClaw in Cloudflare Sandbox uses multiple authentication layers:
 
 **Slow first request:** Cold starts take 1-2 minutes. Subsequent requests are faster.
 
-**R2 not mounting:** Check that all three R2 secrets are set (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `CF_ACCOUNT_ID`). Note: R2 mounting only works in production, not with `wrangler dev`.
+**R2 not mounting:** Check that all three R2 secrets are set (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `CLOUDFLARE_ACCOUNT_ID`). Note: R2 mounting only works in production, not with `wrangler dev`.
 
 **Access denied on admin routes:** Ensure `CF_ACCESS_TEAM_DOMAIN` and `CF_ACCESS_AUD` are set, and that your Cloudflare Access application is configured correctly.
 


### PR DESCRIPTION
…as per wrangler.json and web UI, that's the correct naming for R2 persistent storage.

<img width="1202" height="228" alt="Screenshot 2026-04-11 at 4 28 04 PM" src="https://github.com/user-attachments/assets/f5911a80-2be7-4711-9358-4606e4583ad3" />
