### PR TITLE
fix(ws): normalize reserved close codes in proxy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { ensureGateway, findExistingGatewayProcess, killGateway } from './gatewa
 import { publicRoutes, api, adminUi, debug, cdp } from './routes';
 import { redactSensitiveParams } from './utils/logging';
 import { restoreIfNeeded, createSnapshot } from './persistence';
+import { normalizeWebSocketCloseCode } from './websocket-close';
 import { handleScheduled } from './cron/handler';
 import loadingPageHtml from './assets/loading.html';
 import configErrorHtml from './assets/config-error.html';
@@ -439,7 +440,7 @@ app.all('*', async (c) => {
       if (debugLogs) {
         console.log('[WS] Client closed:', event.code, event.reason);
       }
-      containerWs.close(event.code, event.reason);
+      containerWs.close(normalizeWebSocketCloseCode(event.code), event.reason);
     });
 
     containerWs.addEventListener('close', (event) => {
@@ -454,7 +455,7 @@ app.all('*', async (c) => {
       if (debugLogs) {
         console.log('[WS] Transformed close reason:', reason);
       }
-      serverWs.close(event.code, reason);
+      serverWs.close(normalizeWebSocketCloseCode(event.code), reason);
     });
 
     // Handle errors

--- a/src/websocket-close.test.ts
+++ b/src/websocket-close.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeWebSocketCloseCode } from './websocket-close';
+
+describe('normalizeWebSocketCloseCode', () => {
+  it('preserves valid standard close codes', () => {
+    expect(normalizeWebSocketCloseCode(1000)).toBe(1000);
+    expect(normalizeWebSocketCloseCode(1001)).toBe(1001);
+    expect(normalizeWebSocketCloseCode(1011)).toBe(1011);
+  });
+
+  it('preserves valid application close codes', () => {
+    expect(normalizeWebSocketCloseCode(3000)).toBe(3000);
+    expect(normalizeWebSocketCloseCode(4999)).toBe(4999);
+  });
+
+  it('maps reserved close codes to a safe fallback', () => {
+    expect(normalizeWebSocketCloseCode(1004)).toBe(1011);
+    expect(normalizeWebSocketCloseCode(1005)).toBe(1011);
+    expect(normalizeWebSocketCloseCode(1006)).toBe(1011);
+    expect(normalizeWebSocketCloseCode(1015)).toBe(1011);
+  });
+});

--- a/src/websocket-close.ts
+++ b/src/websocket-close.ts
@@ -1,0 +1,14 @@
+export function normalizeWebSocketCloseCode(code: number): number {
+  if (
+    code === 1000 ||
+    code === 1001 ||
+    code === 1002 ||
+    code === 1003 ||
+    (code >= 1007 && code <= 1014) ||
+    (code >= 3000 && code <= 4999)
+  ) {
+    return code;
+  }
+
+  return 1011;
+}


### PR DESCRIPTION
## Summary
- normalize outbound WebSocket close codes before forwarding them across the proxy
- map reserved/invalid close codes like `1006` to a valid fallback (`1011`)
- add focused tests covering valid and reserved close-code handling

## Problem
The proxy was forwarding peer close codes directly with `ws.close(event.code, ...)`. Reserved codes such as `1006` are not valid in outbound close frames, so forwarding them throws at runtime and can leave proxy handling stuck.

## Notes
This keeps the existing close-reason behavior intact and only normalizes the close code before sending it onward.

Fixes #260
